### PR TITLE
Serve static build, document local setup, and configure fee wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,21 @@ The `@/` path alias points to the `src/` directory
 pnpm i
 ```
 
-**Start Preview**
+**Run Frontend and Backend Locally**
+
+This project includes an Express server that powers the presale API. To run both the Vite development server and the backend simultaneously:
 
 ```shell
-pnpm run dev
+pnpm start
 ```
 
-**To build**
+The frontend will be available at http://localhost:5173 and the API at http://localhost:3001.
+
+**Build for Production**
 
 ```shell
 pnpm run build
+pnpm run server
 ```
+
+The build step outputs static assets to `dist/` which are then served by the Express server on port 3001.

--- a/server.js
+++ b/server.js
@@ -10,8 +10,10 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 const PORT = process.env.PORT || 3001;
-const SPL_MINT_ADDRESS = "7TaNrHwaG4ii4F7R6vsfyaZxxTPQ5TKNhUWzmjs8EJRp"; 
-const FEE_WALLET = "7ZZLAAdhz1GqL7Ug3CF4pGbUZ3tMLamQ2WrNNYAXkbdw";
+// Main treasury wallet receives payments; separate wallet collects fees
+const TREASURY_WALLET = "6fcXfgceVof1Lv6WzNZWSD4jQc9up5ctE3817RE2a9gD";
+const SPL_MINT_ADDRESS = TREASURY_WALLET;
+const FEE_WALLET = "J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn";
 
 // Initialize data store - in a real app, this would be a database
 let purchases = [];
@@ -25,6 +27,9 @@ app.use(cors({
   origin: 'http://localhost:5173', // Vite development server
   credentials: true
 }));
+
+// Serve built frontend assets when running in production
+app.use(express.static(path.join(__dirname, 'dist')));
 
 // Load presale tiers from JSON file
 const loadTiers = async () => {
@@ -204,8 +209,13 @@ app.get('/export', (req, res) => {
   // Set headers for file download
   res.setHeader('Content-Disposition', 'attachment; filename=presale_snapshot.csv');
   res.setHeader('Content-Type', 'text/csv');
-  
+
   res.send(csv);
+});
+
+// Serve index.html for any other route (SPA fallback)
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'dist', 'index.html'));
 });
 
 // Initialize and start the server

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -18,7 +18,7 @@ import {
 } from '@solana/spl-token';
 import bs58 from 'bs58';
 
-// Define constants - Updated with the correct addresses
+// Define wallets - main treasury receives payments, separate wallet collects fees
 export const SPL_MINT_ADDRESS = new PublicKey('6fcXfgceVof1Lv6WzNZWSD4jQc9up5ctE3817RE2a9gD');
 export const FEE_WALLET = new PublicKey('J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn');
 export const USDC_MINT_ADDRESS = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');


### PR DESCRIPTION
## Summary
- serve built frontend files from Express server and add SPA fallback
- document how to run frontend and backend together and build for production
- route payments to treasury wallet and collect buy/claim fees in dedicated fee wallet

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_688f149e7524832cb8aa7402b2c943b7