### PR TITLE
feat: add mobile wallet adapter and persistent backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -9,15 +9,15 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 4444; // τρέχουμε στη θύρα 4444
 
 // Σταθερές για τα wallets/tokens (όπως πριν)
 const SPL_MINT_ADDRESS = 'GgzjNE5YJ8FQ4r1Ts4vfUUq87ppv5qEZQ9uumVM7txGs';
 const TREASURY_WALLET  = '6fcXfgceVof1Lv6WzNZWSD4jQc9up5ctE3817RE2a9gD';
 const FEE_WALLET       = 'J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn';
 
-// CORS για παραγωγή + localhost
-const allowedOrigins = (process.env.CORS_ORIGIN || 'http://localhost:5173').split(',');
+// CORS: επιτρέπει το Vercel domain και το localhost
+const allowedOrigins = (process.env.CORS_ORIGIN || 'http://localhost:5173,https://happypennisofficialpresale.vercel.app').split(',');
 app.use(cors({ origin: allowedOrigins, credentials: true }));
 app.use(express.json());
 
@@ -25,8 +25,8 @@ app.use(express.json());
 let purchases = [];
 let claims    = [];
 
-// Διαδρομές για τα αρχεία δεδομένων
-const DATA_DIR      = path.join(__dirname, 'data');
+// Διαδρομές για τα αρχεία δεδομένων - αποθήκευση σε mounted volume
+const DATA_DIR       = '/data';
 const PURCHASES_FILE = path.join(DATA_DIR, 'purchases.json');
 const CLAIMS_FILE    = path.join(DATA_DIR, 'claims.json');
 
@@ -211,6 +211,6 @@ app.get('/export', (req, res) => {
 (async () => {
   await initializeData();
   app.listen(PORT, () => {
-    console.log(`🚀 Backend running on http://localhost:${PORT}`);
+    console.log(`🚀 Backend running on port ${PORT}`);
   });
 })();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@solana/wallet-adapter-react-ui": "^0.9.34",
     "@solana/wallet-adapter-wallets": "^0.19.23",
     "@solana/web3.js": "^1.87.6",
+    "@solana-mobile/wallet-adapter-mobile": "^1.0.0",
     "@supabase/supabase-js": "^2.50.3",
     "@tanstack/react-query": "^5.56.2",
     "bs58": "^5.0.0",

--- a/src/components/SolanaWalletProvider.tsx
+++ b/src/components/SolanaWalletProvider.tsx
@@ -1,7 +1,16 @@
 import { FC, ReactNode, useMemo } from 'react';
 import { ConnectionProvider, WalletProvider } from '@solana/wallet-adapter-react';
 import { WalletAdapterNetwork } from '@solana/wallet-adapter-base';
-import { PhantomWalletAdapter, SolflareWalletAdapter, TorusWalletAdapter, LedgerWalletAdapter } from '@solana/wallet-adapter-wallets';
+import {
+  PhantomWalletAdapter,
+  SolflareWalletAdapter,
+  TorusWalletAdapter,
+  LedgerWalletAdapter,
+} from '@solana/wallet-adapter-wallets';
+import {
+  MobileWalletAdapter,
+  BrowserLocalStorageStore,
+} from '@solana-mobile/wallet-adapter-mobile';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { SOLANA_RPC_URL } from '@/lib/solana';
 
@@ -19,6 +28,14 @@ export const SolanaWalletProvider: FC<SolanaWalletProviderProps> = ({ children }
   // Configure supported wallets
   const wallets = useMemo(
     () => [
+      new MobileWalletAdapter({
+        appIdentity: {
+          name: 'Happy Penis Presale',
+          uri: 'https://happypennisofficialpresale.vercel.app',
+          icon: 'https://happypennisofficialpresale.vercel.app/logo192.png',
+        },
+        authorizationResultCache: new BrowserLocalStorageStore(),
+      }),
       new PhantomWalletAdapter(),
       new SolflareWalletAdapter(),
       new TorusWalletAdapter(),


### PR DESCRIPTION
## Summary
- persist backend data in `/data`, listen on port 4444, and allow Vercel origin via CORS
- add MobileWalletAdapter support and dependency for mobile wallets

## Testing
- `pnpm lint`
- `pnpm add @solana-mobile/wallet-adapter-mobile` *(fails: GET 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689203544448832cb6525d443273bc03