### PR TITLE
Fix mobile wallet adapter setup

### DIFF
--- a/src/components/SolanaWalletProvider.tsx
+++ b/src/components/SolanaWalletProvider.tsx
@@ -7,7 +7,7 @@ import {
   TorusWalletAdapter,
   LedgerWalletAdapter,
 } from '@solana/wallet-adapter-wallets';
-import { MobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile';
+import { SolanaMobileWalletAdapter as MobileWalletAdapter } from '@solana-mobile/wallet-adapter-mobile';
 import { WalletModalProvider } from '@solana/wallet-adapter-react-ui';
 import { SOLANA_RPC_URL } from '@/lib/solana';
 
@@ -33,8 +33,8 @@ export const SolanaWalletProvider: FC<SolanaWalletProviderProps> = ({ children }
         },
       }),
       new PhantomWalletAdapter(),
-      new SolflareWalletAdapter(),
-      new TorusWalletAdapter(),
+      new SolflareWalletAdapter({ network }),
+      new TorusWalletAdapter({ params: { env: network } }),
       new LedgerWalletAdapter(),
     ],
     [network]


### PR DESCRIPTION
## Summary
- import SolanaMobileWalletAdapter correctly and alias as MobileWalletAdapter
- build wallet list with mobile adapter and network-configured adapters

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68924bc74ad0832cad57decef959c275