### PR TITLE
fix: guard toast timeout map

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -50,22 +50,24 @@ interface State {
   toasts: ToasterToast[];
 }
 
-const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+let toastTimeouts: Map<string, ReturnType<typeof setTimeout>> | undefined;
 
 const addToRemoveQueue = (toastId: string) => {
+  toastTimeouts ??= new Map();
+
   if (toastTimeouts.has(toastId)) {
     return;
   }
 
   const timeout = setTimeout(() => {
-    toastTimeouts.delete(toastId);
+    toastTimeouts?.delete(toastId);
     dispatch({
       type: 'REMOVE_TOAST',
       toastId: toastId,
     });
   }, TOAST_REMOVE_DELAY);
 
-  toastTimeouts.set(toastId, timeout);
+  toastTimeouts?.set(toastId, timeout);
 };
 
 export const reducer = (state: State, action: Action): State => {


### PR DESCRIPTION
## Summary
- guard toastTimeouts before calling set to avoid errors when map is undefined

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689272e3efcc832cbddbd0f8e2ea4a13