### PR TITLE
Log can-claim request bodies and missing wallets

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -175,12 +175,17 @@ app.get('/can-claim/:wallet', (req, res) => {
 
 // can-claim bulk
 app.post('/can-claim', (req, res) => {
+  console.log('📦 /can-claim raw body:', req.body);
   const wallets = Array.isArray(req.body) ? req.body : req.body?.wallets;
   if (!Array.isArray(wallets)) {
+    console.warn('⚠️  /can-claim invalid payload:', req.body);
     return res.status(400).json({ error: 'wallets must be an array' });
   }
   const results = wallets.map(wallet => {
     const userPurchases = purchases.filter(p => p.wallet === wallet);
+    if (userPurchases.length === 0) {
+      console.debug(`🔍 /can-claim checked wallet with no purchases: ${wallet}`);
+    }
     const totalTokens = userPurchases.reduce((sum, p) => sum + Number(p.amount || 0), 0);
     const anyClaimed = userPurchases.some(p => p.claimed);
     return {


### PR DESCRIPTION
## Summary
- log raw /can-claim POST body for debugging
- warn when wallets payload isn't an array and note missing wallets
- debug each wallet in bulk check that has no purchases

## Testing
- `npm test` *(fails: Missing script "test")*
- `node backend/server.js` then `curl -s -X POST http://localhost:8080/can-claim -H 'Content-Type: application/json' -d '{"wallets":"abc"}'`
- `curl -s -X POST http://localhost:8080/can-claim -H 'Content-Type: application/json' -d '{"wallets":["w1","w2"]}'`


------
https://chatgpt.com/codex/tasks/task_e_689783a86344832cbd5ce77ade6f689a