### PR TITLE
Allow wildcard CORS origins and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,32 @@ pnpm run dev
 ```shell
 pnpm run build
 ```
+
+## Backend CORS configuration
+
+The backend reads allowed origins from the `CORS_ORIGIN` environment variable.
+Provide a comma‑separated list of origins or wildcard patterns. The character
+`*` can be used to match any subdomain, and a lone `*` allows all origins. If
+omitted, the server defaults to `http://localhost:5173` for development.
+
+```bash
+CORS_ORIGIN="https://*.example.com,http://localhost:5173"
+node backend/server.js
+```
+
+For this project the variable is typically set to:
+
+```bash
+CORS_ORIGIN="https://happypennisofficialpresale.vercel.app,https://happypennisofficialpresale-e1syb8uhk-proffesorsafas-projects.vercel.app,http://localhost:5173"
+```
+
+### Mobile/iOS deployments
+
+When running inside a mobile WebView (e.g. iOS with Capacitor), include the
+scheme used by the app:
+
+```bash
+CORS_ORIGIN="capacitor://localhost,https://*.example.com"
+```
+
+This permits requests from the mobile application alongside web domains.

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,13 +16,35 @@ const SPL_MINT_ADDRESS = 'GgzjNE5YJ8FQ4r1Ts4vfUUq87ppv5qEZQ9uumVM7txGs';
 const TREASURY_WALLET  = '6fcXfgceVof1Lv6WzNZWSD4jQc9up5ctE3817RE2a9gD';
 const FEE_WALLET       = 'J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn';
 
-// CORS (πρόσθεσα presale-happypenis.com και localhost)
-const allowedOrigins = (process.env.CORS_ORIGIN || 
-  'https://happypennisofficialpresale.vercel.app,https://presale-happypenis.com,http://localhost:3000'
-).split(',').map(o => o.trim());
+// CORS configuration: read allowed origins from `CORS_ORIGIN`.
+// Defaults to Vite's dev server (`http://localhost:5173`).
+const originPatterns = (process.env.CORS_ORIGIN ||
+  'http://localhost:5173'
+).split(',').map(o => o.trim()).filter(Boolean);
 
-app.use(cors({ origin: allowedOrigins, credentials: true }));
-app.options('*', cors({ origin: allowedOrigins, credentials: true }));
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|\\]/g, '\\$&');
+}
+
+const originMatchers = originPatterns.map(p =>
+  p === '*'
+    ? /.*/
+    : new RegExp('^' + escapeRegex(p).replace(/\\\*/g, '.*') + '$')
+);
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || originMatchers.some(re => re.test(origin))) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+};
+
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 app.use(express.json());
 
 // In-memory + persistent store


### PR DESCRIPTION
## Summary
- expand CORS handling to support wildcard origin patterns and custom checks
- document `CORS_ORIGIN` usage, defaulting to Vite's 5173 port and include deployment example
- clarify default CORS origin to localhost for development

## Testing
- `pnpm test` *(fails: Missing script: test)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68979dd0f398832cbca7e86f3ef659f2