### PR TITLE
Improve backend write safety and purchase retries

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -194,13 +194,14 @@ export default function PresalePage() {
       if (!txSignature) throw new Error("No transaction signature returned");
         (window as typeof window & { lastTransactionSignature?: string }).lastTransactionSignature = txSignature;
 
-      await recordPurchase(
+      const rec = await recordPurchase(
         publicKey.toString(),
         penisAmount,
         paymentToken,
         txSignature,
         { total_paid_usdc, total_paid_sol, fee_paid_usdc, fee_paid_sol }
       );
+      if (!rec) { toast.error("Purchase recorded failed. Try again."); return; }
 
       setTotalRaised(prev => prev + penisAmount);
       setAmount("");


### PR DESCRIPTION
## Summary
- use atomic file writes with serialized queue and full CORS list
- ensure /can-claim always reads fresh data and expose debug endpoints
- retry purchase recording with `keepalive` and show success only when stored

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_6897bcdbdde8832c8af8e16b3cd05e06