### PR TITLE
docs: document API base URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ All shadcn/ui components have been downloaded under `@/components/ui`.
 
 The `@/` path alias points to the `src/` directory
 
+## API Base URL
+
+The frontend uses the `VITE_API_BASE_URL` environment variable to determine where API requests are sent. It defaults to `/api`. When running the backend directly without a reverse proxy, override this value (for example, `VITE_API_BASE_URL=http://localhost:8080`) to avoid 404 errors on endpoints such as `/status` or `/can-claim`.
+
 # Commands
 
 **Install Dependencies**


### PR DESCRIPTION
## Summary
- explain default `/api` base URL for API requests
- instruct overriding `VITE_API_BASE_URL` when running backend without reverse proxy to prevent 404s

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6898679360f8832cb2e5c263ac927454