### PR TITLE
Remove duplicate admin secret declarations and fix Solana connection

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -37,15 +37,6 @@ const FEE_WALLET       = "J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn";
 const PRESALE_END_AT   = process.env.PRESALE_END_AT || ""; // ISO string αν θέλεις να κλείσει η presale
 const short = (w = "") => String(w).slice(0, 6) + "...";
 
-const ADMIN_SECRET = process.env.ADMIN_SECRET || "";
-
-function requireAdmin(req, res, next) {
-  if (!ADMIN_SECRET) return res.status(403).json({ error: "ADMIN_ONLY" });
-  const k = req.get("x-admin-secret") || req.query.key;
-  if (k !== ADMIN_SECRET) return res.status(403).json({ error: "ADMIN_ONLY" });
-  next();
-}
-
 // ----------- Anti-cache για όλα τα API JSON που αλλάζουν συχνά -----------
 app.set("etag", false);
 app.use((req, res, next) => {

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -18,6 +18,10 @@ const WS_ENDPOINT =
   ENV.SOLANA_WS_URL ||
   'wss://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834787a11ae2';
 
+const connection = new Connection(RPC_ENDPOINT, {
+  commitment: 'confirmed',
+  wsEndpoint: WS_ENDPOINT,
+});
 
 
 // ====== ✅ CONSTANTS (με τα δικά σου, με env fallback) ======


### PR DESCRIPTION
## Summary
- Remove redundant ADMIN_SECRET variable and extra requireAdmin definition
- Define a Solana RPC connection so wallet balance checks and transactions work

## Testing
- `pnpm lint`
- `pnpm build`
- `node backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_6899ac6b2dcc832cb98e471f8c80d215