### PR TITLE
Refactor presale flow and parameterize deployment URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ The frontend reads the `VITE_API_BASE_URL` environment variable to know where to
 
 When running the backend directly (without serving it behind `/api`), set this variable to the backend's full URL to prevent 404 errors on endpoints like `/status` or `/can-claim`.
 
+## Production redirect URL
+
+When a wallet connects inside a mobile in-app browser, the page redirects to `VITE_PROD_URL`. Set this variable in your `.env` files to control the destination URL. It defaults to the official presale site.
+
 Create a `.env.local` file with:
 
 ```

--- a/backend/server.js
+++ b/backend/server.js
@@ -143,8 +143,14 @@ function updateCurrentTier() {
 app.get("/", (req, res) => res.send("Happy Penis API ✓"));
 app.get("/healthz", (req, res) => res.json({ ok: true, time: Date.now() }));
 
-// current tier (ένα αντικείμενο)
+// full tier list
 app.get("/tiers", async (req, res) => {
+  if (presaleTiers.length === 0) await initializeData();
+  res.json(presaleTiers);
+});
+
+// current tier (single object)
+app.get("/current-tier", async (req, res) => {
   if (presaleTiers.length === 0) await initializeData();
   updateCurrentTier();
   res.json(presaleTiers[currentTierIndex] || {});

--- a/src/components/ClaimSection.tsx
+++ b/src/components/ClaimSection.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@/components/ui/button";
+
+interface ClaimInfo {
+  canClaim: boolean;
+  total?: string;
+}
+
+interface Props {
+  connected: boolean;
+  isCheckingStatus: boolean;
+  claimableTokens: ClaimInfo | null;
+  presaleEnded: boolean;
+  claimTokens: () => void;
+  isClaimPending: boolean;
+}
+
+export default function ClaimSection({
+  connected,
+  isCheckingStatus,
+  claimableTokens,
+  presaleEnded,
+  claimTokens,
+  isClaimPending,
+}: Props) {
+  if (!connected) return null;
+
+  return (
+    <div className="bg-pink-500/20 p-4 rounded-md border border-pink-500">
+      <h3 className="font-medium text-center mb-2">
+        {isCheckingStatus ? "Checking claim status..." : "Token Claim"}
+      </h3>
+      {isCheckingStatus ? (
+        <div className="flex justify-center py-2">
+          <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-pink-500"></div>
+        </div>
+      ) : claimableTokens === null ? (
+        <p className="text-sm text-center">Unable to check claim status</p>
+      ) : (
+        <>
+          {claimableTokens.total !== undefined && (
+            <p className="text-sm text-center mb-3">
+              You can claim {""}
+              <span className="font-bold">
+                {parseInt(claimableTokens.total, 10).toLocaleString()}
+              </span>{" "}
+              PENIS tokens
+            </p>
+          )}
+          {presaleEnded && claimableTokens.canClaim ? (
+            <>
+              <Button
+                onClick={claimTokens}
+                disabled={isClaimPending}
+                className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600"
+              >
+                {isClaimPending ? "Processing..." : "Claim Tokens"}
+              </Button>
+              <p className="text-xs text-center mt-2 text-gray-300">
+                A small fee will be charged to process your claim
+              </p>
+            </>
+          ) : (
+            <p className="text-sm text-center">Claims open after the presale.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import type { TierInfo } from "@/lib/api";
+
+interface Props {
+  currentTier: TierInfo;
+  label?: string;
+  className?: string;
+}
+
+export default function CountdownTimer({ currentTier, label = "Presale ends in:", className }: Props) {
+  const [time, setTime] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (currentTier.tier <= 3) {
+      setTime("No time limit - Complete sale to advance");
+      return;
+    }
+    const tierStartDate = new Date("2025-08-01");
+    const tierEndDate = new Date(tierStartDate);
+    const duration = currentTier.duration_days || 30;
+    tierEndDate.setDate(tierEndDate.getDate() + duration);
+
+    const update = () => {
+      const diff = tierEndDate.getTime() - Date.now();
+      if (diff <= 0) {
+        setTime("Tier ended");
+        return;
+      }
+      const d = Math.floor(diff / 86400000);
+      const h = Math.floor((diff % 86400000) / 3600000);
+      const m = Math.floor((diff % 3600000) / 60000);
+      const s = Math.floor((diff % 60000) / 1000);
+      setTime(`${d}d ${h}h ${m}m ${s}s`);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [currentTier]);
+
+  if (!time) return null;
+
+  return (
+    <div className={className}>
+      <p className="text-xs text-gray-400">{label}</p>
+      <p className="font-mono text-sm">{time}</p>
+    </div>
+  );
+}

--- a/src/components/CustomWalletButton.tsx
+++ b/src/components/CustomWalletButton.tsx
@@ -2,91 +2,10 @@
 import { WalletMultiButton } from "@solana/wallet-adapter-react-ui";
 
 export function CustomWalletButton() {
-  // Χρησιμοποιούμε έτοιμο MultiButton για σωστή επιλογή/σύνδεση/αποσύνδεση + modal
+  // Use built-in MultiButton for wallet selection/connect/disconnect
   return (
     <div className="relative z-[10000]">
       <WalletMultiButton className="!bg-gradient-to-r !from-pink-500 !to-purple-500 !text-white !rounded-xl !px-4 !py-2 !h-auto" />
-    </div>
-  );
-}
-
-
-
-export function CustomWalletButton() {
-  const {
-    wallets,
-    wallet,
-    select,
-    connect,
-    disconnect,
-    connected,
-    connecting,
-    publicKey,
-  } = useWallet();
-
-  const short = useMemo(
-    () => (publicKey ? `${publicKey.toBase58().slice(0, 4)}…${publicKey.toBase58().slice(-4)}` : ""),
-    [publicKey]
-  );
-
-  const pickDefault = () => {
-    const by = (name: string) =>
-      wallets.find((w) => w.adapter.name.toLowerCase().includes(name));
-    return (
-      by("phantom")?.adapter.name ||
-      by("solflare")?.adapter.name ||
-      wallets[0]?.adapter.name
-    );
-  };
-
-  const doConnect = async () => {
-    // Αν είμαστε σε mobile browser ΧΩΡΙΣ injected wallet → δείξε το banner (όχι connect εδώ)
-    if (isMobileUA() && !hasInjected()) {
-      alert("Open this page inside Phantom or Solflare (use the buttons at the bottom).");
-      return;
-    }
-    const name = pickDefault();
-    if (name) await select(name);
-    await connect();
-  };
-
-  const changeWallet = async () => {
-    const current = wallet?.adapter.name;
-    const others = wallets.filter((w) => w.adapter.name !== current);
-    if (!others.length) return;
-    await disconnect().catch(() => {});
-    await select(others[0].adapter.name);
-    await connect();
-  };
-
-  // --- UI ---
-  if (!connected) {
-    return (
-      <button
-        onClick={doConnect}
-        disabled={connecting}
-        className="z-[9999] rounded-xl px-4 py-2 bg-pink-600 hover:bg-pink-700 text-white font-semibold shadow"
-      >
-        {connecting ? "Connecting…" : "Connect Wallet"}
-      </button>
-    );
-  }
-
-  return (
-    <div className="z-[9999] flex items-center gap-2">
-      <span className="text-white/90 text-sm hidden sm:inline">{short}</span>
-      <button
-        onClick={changeWallet}
-        className="rounded-xl px-3 py-2 bg-gray-800 hover:bg-gray-700 text-white"
-      >
-        Change
-      </button>
-      <button
-        onClick={() => disconnect().catch(() => {})}
-        className="rounded-xl px-3 py-2 bg-gray-800 hover:bg-gray-700 text-white"
-      >
-        Disconnect
-      </button>
     </div>
   );
 }

--- a/src/components/PurchaseForm.tsx
+++ b/src/components/PurchaseForm.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import type { PaymentToken } from "@/lib/api";
+
+interface Props {
+  amount: string;
+  setAmount: (v: string) => void;
+  paymentToken: PaymentToken;
+  setPaymentToken: (v: PaymentToken) => void;
+  buyTokens: () => void;
+  isPending: boolean;
+  connected: boolean;
+}
+
+export default function PurchaseForm({
+  amount,
+  setAmount,
+  paymentToken,
+  setPaymentToken,
+  buyTokens,
+  isPending,
+  connected,
+}: Props) {
+  return (
+    <>
+      <div className="grid gap-2">
+        <Label htmlFor="amount">Amount of PENIS tokens</Label>
+        <Input
+          id="amount"
+          placeholder="Enter amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          type="number"
+          min="1"
+          className="bg-gray-800/50"
+        />
+      </div>
+      <div className="grid gap-2">
+        <Label htmlFor="token">Payment Token</Label>
+        <Select value={paymentToken} onValueChange={(v: PaymentToken) => setPaymentToken(v)}>
+          <SelectTrigger className="bg-gray-800/50">
+            <SelectValue placeholder="Select token" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="USDC">USDC</SelectItem>
+            <SelectItem value="SOL">SOL</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        onClick={buyTokens}
+        disabled={!connected || isPending || !amount}
+        className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600"
+      >
+        {isPending ? "Processing..." : "Buy Now"}
+      </Button>
+      {!connected && (
+        <p className="text-center text-sm text-gray-400">Connect your wallet to buy tokens</p>
+      )}
+    </>
+  );
+}

--- a/src/components/TierInfoList.tsx
+++ b/src/components/TierInfoList.tsx
@@ -1,0 +1,34 @@
+import type { TierInfo } from "@/lib/api";
+
+interface Props {
+  tiers: TierInfo[];
+  currentTier: TierInfo;
+}
+
+export default function TierInfoList({ tiers, currentTier }: Props) {
+  return (
+    <div className="space-y-2">
+      {tiers.map((tier) => (
+        <div
+          key={tier.tier}
+          className={`p-3 rounded-md border ${
+            currentTier.tier === tier.tier
+              ? "bg-pink-500/20 border-pink-500"
+              : "bg-gray-800/50 border-gray-700"
+          }`}
+        >
+          <div className="flex justify-between">
+            <h4 className="font-medium">Tier {tier.tier}</h4>
+            <span>{tier.price_usdc} USDC</span>
+          </div>
+          <div className="text-xs text-gray-400 mt-1">
+            <span>Limit: {tier.max_tokens.toLocaleString()} PENIS</span>
+            {tier.duration_days && (
+              <span className="ml-2">Duration: {tier.duration_days} days</span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/use-presale.ts
+++ b/src/hooks/use-presale.ts
@@ -1,0 +1,230 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
+import { toast } from "sonner";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  executeSOLPayment,
+  executeUSDCPayment,
+  executeClaimFeePayment,
+  BUY_FEE_PERCENTAGE,
+} from "@/lib/solana";
+import {
+  recordPurchase,
+  canClaimTokensBulk,
+  recordClaim,
+  getPresaleStatus,
+  getPresaleTiers,
+  type TierInfo,
+  type PaymentToken,
+} from "@/lib/api";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+const SOL_TO_USDC_RATE = 170;
+const PROD_URL = (import.meta.env.VITE_PROD_URL as string) || "https://happypennisofficialpresale.vercel.app/";
+
+export function usePresale() {
+  const { toast: uiToast } = useToast();
+  const { publicKey, connected, signTransaction, sendTransaction, connect } = useWallet();
+  const isMobile = useIsMobile();
+
+  const [tiers, setTiers] = useState<TierInfo[]>([]);
+  const [currentTier, setCurrentTier] = useState<TierInfo | null>(null);
+  const [totalRaised, setTotalRaised] = useState(0);
+  const [amount, setAmount] = useState("");
+  const [paymentToken, setPaymentToken] = useState<PaymentToken>("SOL");
+  const [isPending, setIsPending] = useState(false);
+  const [presaleEnded, setPresaleEnded] = useState(false);
+  const [claimableTokens, setClaimableTokens] = useState<null | { canClaim: boolean; total?: string }>(null);
+  const [isClaimPending, setIsClaimPending] = useState(false);
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+
+  const lastWallet = useRef<string | null>(null);
+
+  const hasInjected = () => {
+    if (typeof window === "undefined") return false;
+    const w = window as typeof window & { solana?: { isPhantom?: boolean }; solflare?: unknown };
+    return w.solana?.isPhantom || w.solflare;
+  };
+
+  useEffect(() => {
+    if (isMobile && hasInjected() && !connected) connect().catch(() => {});
+  }, [connected, connect, isMobile]);
+
+  useEffect(() => {
+    if (connected) {
+      const target = PROD_URL;
+      if (typeof window !== "undefined" && window.location.href !== target) {
+        window.location.href = target;
+      }
+    }
+  }, [connected]);
+
+  useEffect(() => {
+    if (connected && publicKey) {
+      const key = publicKey.toString();
+      if (lastWallet.current !== key) {
+        lastWallet.current = key;
+        checkClaimStatus();
+      }
+    } else {
+      setClaimableTokens(null);
+      lastWallet.current = null;
+    }
+  }, [connected, publicKey]);
+
+  useEffect(() => {
+    fetchPresaleStatus();
+  }, []);
+
+  useEffect(() => {
+    if (!tiers.length) return;
+    let raisedSoFar = 0;
+    for (const tier of tiers) {
+      if (raisedSoFar + tier.max_tokens > totalRaised) {
+        setCurrentTier(tier);
+        break;
+      }
+      raisedSoFar += tier.max_tokens;
+    }
+  }, [totalRaised, tiers]);
+
+  const fetchPresaleStatus = async () => {
+    try {
+      setIsCheckingStatus(true);
+      const status = await getPresaleStatus();
+      if (status) {
+        setTotalRaised(status.raised);
+        setPresaleEnded(!!status.presaleEnded);
+        setCurrentTier(status.currentTier);
+      }
+      const tierList = await getPresaleTiers();
+      setTiers(tierList);
+    } catch (e) {
+      console.error("status error:", e);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
+
+  const checkClaimStatus = async () => {
+    if (!publicKey || !connected) return;
+    try {
+      setIsCheckingStatus(true);
+      const map = await canClaimTokensBulk([publicKey.toString()]);
+      const info = map.get(publicKey.toString());
+      setClaimableTokens(info ? { canClaim: info.canClaim, total: info.total } : null);
+    } catch {
+      toast.error("Failed to check claim status");
+      setClaimableTokens(null);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
+
+  const buyTokens = async () => {
+    toast.info("Starting purchase process...");
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey) { toast.error("Wallet not connected"); return; }
+    if (!amount || parseFloat(amount) <= 0 || !currentTier) { toast.error("Invalid amount"); return; }
+
+    setIsPending(true);
+    try {
+      const penisAmount = parseFloat(amount);
+      const totalPriceUSDC = penisAmount * currentTier.price_usdc;
+      const feePct = BUY_FEE_PERCENTAGE / 100;
+      let txSignature: string | null = null;
+      let total_paid_usdc: number | null = null;
+      let total_paid_sol: number | null = null;
+      let fee_paid_usdc: number | null = null;
+      let fee_paid_sol: number | null = null;
+
+      if (paymentToken === "SOL" && publicKey && signTransaction) {
+        const solAmount = totalPriceUSDC / SOL_TO_USDC_RATE;
+        txSignature = await executeSOLPayment(solAmount, { publicKey, signTransaction, sendTransaction });
+        total_paid_sol = +solAmount.toFixed(6);
+        fee_paid_sol = +(solAmount * feePct).toFixed(6);
+      } else if (paymentToken === "USDC" && publicKey && signTransaction) {
+        txSignature = await executeUSDCPayment(totalPriceUSDC, { publicKey, signTransaction, sendTransaction });
+        total_paid_usdc = +totalPriceUSDC.toFixed(6);
+        fee_paid_usdc = +(totalPriceUSDC * feePct).toFixed(6);
+      } else {
+        toast.error("Invalid payment method or wallet not properly connected");
+        throw new Error("payment method");
+      }
+
+      if (!txSignature) throw new Error("No transaction signature returned");
+      (window as unknown as { lastTransactionSignature?: string }).lastTransactionSignature = txSignature;
+
+      const rec = await recordPurchase({
+        wallet: publicKey.toString(),
+        amount: penisAmount,
+        token: paymentToken,
+        transaction_signature: txSignature,
+        total_paid_usdc: total_paid_usdc ?? undefined,
+        total_paid_sol: total_paid_sol ?? undefined,
+        fee_paid_usdc: fee_paid_usdc ?? undefined,
+        fee_paid_sol: fee_paid_sol ?? undefined,
+        price_usdc_each: currentTier.price_usdc,
+      });
+      if (!rec) { toast.error("Purchase record failed. Try again."); return; }
+
+      setTotalRaised((prev) => prev + penisAmount);
+      setAmount("");
+      checkClaimStatus();
+      toast.success("Purchase completed successfully!");
+    } catch (error) {
+      console.error(error);
+      toast.error("Transaction failed");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const claimTokens = async () => {
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey || !claimableTokens?.canClaim || !claimableTokens.total) return;
+    setIsClaimPending(true);
+    try {
+      const tokenAmount = parseFloat(claimableTokens.total);
+      const txSignature = await executeClaimFeePayment({ publicKey, signTransaction, sendTransaction });
+      if (!txSignature) throw new Error("Claim fee payment failed");
+      const resp = await recordClaim({ wallet: publicKey.toString(), transaction_signature: txSignature });
+      if (!resp?.success) throw new Error("Failed to record claim on server");
+      uiToast({ title: "Claim Successful!", description: `You claimed ${tokenAmount.toLocaleString()} PENIS tokens` });
+      setClaimableTokens({ ...claimableTokens, canClaim: false });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : undefined;
+      uiToast({ title: "Claim Failed", description: message || "Could not complete the claim.", variant: "destructive" });
+    } finally {
+      setIsClaimPending(false);
+    }
+  };
+
+  const goalTokens = useMemo(() => tiers.reduce((s, t) => s + (t.max_tokens || 0), 0), [tiers]);
+  const raisedPercentage = useMemo(() => (totalRaised / goalTokens) * 100, [totalRaised, goalTokens]);
+
+  return {
+    tiers,
+    currentTier,
+    totalRaised,
+    amount,
+    setAmount,
+    paymentToken,
+    setPaymentToken,
+    isPending,
+    presaleEnded,
+    claimableTokens,
+    isClaimPending,
+    isCheckingStatus,
+    buyTokens,
+    claimTokens,
+    connected,
+    goalTokens,
+    raisedPercentage,
+    isMobile,
+  };
+}

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -5,17 +5,14 @@ import { Connection, PublicKey, Transaction, SystemProgram, LAMPORTS_PER_SOL, Tr
 import { createTransferInstruction, getAssociatedTokenAddress, getAccount, createAssociatedTokenAccountInstruction } from "@solana/spl-token";
 
 // ===== RPC (HTTPS + WSS) =====
+const DEFAULT_RPC_HTTP = "https://api.mainnet-beta.solana.com";
 const RAW_HTTP = (import.meta as any)?.env?.VITE_SOLANA_RPC_URL || "";
 const RAW_WS   = (import.meta as any)?.env?.VITE_SOLANA_WS_URL || "";
 
-function assertHttps(u: string) {
-  if (!/^https:\/\//i.test(u)) throw new Error("VITE_SOLANA_RPC_URL must be a valid https:// endpoint");
+function sanitizeHttp(u: string) {
+  return /^https:\/\//i.test(u.trim()) ? u.trim() : DEFAULT_RPC_HTTP;
 }
-const RPC_HTTP = (() => {
-  const u = String(RAW_HTTP).trim();
-  assertHttps(u);
-  return u;
-})();
+const RPC_HTTP = sanitizeHttp(String(RAW_HTTP));
 const RPC_WS   = RAW_WS ? String(RAW_WS).trim() : RPC_HTTP.replace(/^https/i, "wss");
 
 export const connection = new Connection(RPC_HTTP, {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,277 +1,40 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useEffect, useRef, useMemo } from "react";
-import { useWallet } from "@solana/wallet-adapter-react";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { useToast } from "@/components/ui/use-toast";
-import { toast } from "sonner";
-import {
-  executeSOLPayment,
-  executeUSDCPayment,
-  executeClaimFeePayment,
-  formatPublicKey,
-  SPL_MINT_ADDRESS,
-  BUY_FEE_PERCENTAGE,
-} from "@/lib/solana";
-import { CustomWalletButton } from "@/components/CustomWalletButton";
-import { recordPurchase, canClaimTokensBulk, recordClaim, getCurrentTier, getPresaleStatus } from "@/lib/api";
-import MobileOpenInWallet from "@/components/MobileOpenInWallet";
 import { Badge } from "@/components/ui/badge";
-
-type PaymentToken = "SOL" | "USDC";
-
-const PRESALE_TIERS = [
-  { tier: 1, price_usdc: 0.000260, max_tokens: 237500000, duration_days: null },
-  { tier: 2, price_usdc: 0.000312, max_tokens: 237500000, duration_days: null },
-  { tier: 3, price_usdc: 0.000374, max_tokens: 237500000, duration_days: null },
-  { tier: 4, price_usdc: 0.000449, max_tokens: 237500000, duration_days: 30 },
-  { tier: 5, price_usdc: 0.000539, max_tokens: 237500000, duration_days: 30 },
-  { tier: 6, price_usdc: 0.000647, max_tokens: 237500000, duration_days: 30 },
-  { tier: 7, price_usdc: 0.000776, max_tokens: 237500000, duration_days: 30 },
-  { tier: 8, price_usdc: 0.000931, max_tokens: 237500000, duration_days: 30 },
-];
-const GOAL_TOKENS = PRESALE_TIERS.reduce((s, t) => s + (t.max_tokens || 0), 0);
-const SOL_TO_USDC_RATE = 170;
-const PROD_URL = "https://happypennisofficialpresale.vercel.app/";
+import { CustomWalletButton } from "@/components/CustomWalletButton";
+import MobileOpenInWallet from "@/components/MobileOpenInWallet";
+import CountdownTimer from "@/components/CountdownTimer";
+import PurchaseForm from "@/components/PurchaseForm";
+import TierInfoList from "@/components/TierInfoList";
+import ClaimSection from "@/components/ClaimSection";
+import { formatPublicKey, SPL_MINT_ADDRESS } from "@/lib/solana";
+import { usePresale } from "@/hooks/use-presale";
 
 export default function PresalePage() {
-  const { toast: uiToast } = useToast();
-  const { publicKey, connected, signTransaction, sendTransaction, connect } = useWallet();
+  const {
+    tiers,
+    currentTier,
+    totalRaised,
+    amount,
+    setAmount,
+    paymentToken,
+    setPaymentToken,
+    isPending,
+    presaleEnded,
+    claimableTokens,
+    isClaimPending,
+    isCheckingStatus,
+    buyTokens,
+    claimTokens,
+    connected,
+    goalTokens,
+    raisedPercentage,
+    isMobile,
+  } = usePresale();
 
-  const [currentTier, setCurrentTier] = useState(PRESALE_TIERS[0]);
-  const [totalRaised, setTotalRaised] = useState(0);
-  const [amount, setAmount] = useState("");
-  const [paymentToken, setPaymentToken] = useState<PaymentToken>("SOL");
-  const [countdownTime, setCountdownTime] = useState("");
-  const [isPending, setIsPending] = useState(false);
-  const [presaleEnded, setPresaleEnded] = useState(false);
-  const [claimableTokens, setClaimableTokens] =
-    useState<null | { canClaim: boolean; total?: string }>(null);
-  const [isClaimPending, setIsClaimPending] = useState(false);
-  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
-
-  const lastWallet = useRef<string | null>(null);
-
-  const isMobile = () =>
-    typeof navigator !== "undefined" && /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
-  const hasInjected = () => {
-    if (typeof window === "undefined") return false;
-    const w = window as any;
-    return w.solana?.isPhantom || w.solflare;
-  };
-
-  // Auto-connect μέσα σε wallet browser
-  useEffect(() => {
-    if (isMobile() && hasInjected() && !connected) {
-      connect().catch(() => {});
-    }
-  }, [connected, connect]);
-
-  // Αν ανοίχτηκε μέσω banner/wallet, με το που συνδεθεί να πάει στο prod URL
-  useEffect(() => {
-    if (connected) {
-      const target = PROD_URL;
-      if (typeof window !== "undefined" && window.location.href !== target) {
-        window.location.href = target;
-      }
-    }
-  }, [connected]);
-
-  useEffect(() => {
-    if (connected && publicKey) {
-      const key = publicKey.toString();
-      if (lastWallet.current !== key) {
-        lastWallet.current = key;
-        checkClaimStatus();
-      }
-    } else {
-      setClaimableTokens(null);
-      lastWallet.current = null;
-    }
-  }, [connected, publicKey]);
-
-  useEffect(() => {
-    fetchPresaleStatus();
-  }, []);
-
-  useEffect(() => {
-    if (currentTier.tier <= 3) {
-      setCountdownTime("No time limit - Complete sale to advance");
-      return;
-    }
-    const tierStartDate = new Date("2025-08-01");
-    const tierEndDate = new Date(tierStartDate);
-    const duration = currentTier.duration_days || 30;
-    tierEndDate.setDate(tierEndDate.getDate() + duration);
-    const update = () => {
-      const diff = tierEndDate.getTime() - Date.now();
-      if (diff <= 0) {
-        setCountdownTime("Tier ended");
-        return;
-      }
-      const d = Math.floor(diff / 86400000);
-      const h = Math.floor((diff % 86400000) / 3600000);
-      const m = Math.floor((diff % 3600000) / 60000);
-      const s = Math.floor((diff % 60000) / 1000);
-      setCountdownTime(`${d}d ${h}h ${m}m ${s}s`);
-    };
-    update();
-    const interval = setInterval(update, 1000);
-    return () => clearInterval(interval);
-  }, [currentTier]);
-
-  useEffect(() => {
-    let raisedSoFar = 0;
-    for (const tier of PRESALE_TIERS) {
-      if (raisedSoFar + tier.max_tokens > totalRaised) {
-        setCurrentTier(tier);
-        break;
-      }
-      raisedSoFar += tier.max_tokens;
-    }
-  }, [totalRaised]);
-
-  const fetchPresaleStatus = async () => {
-    try {
-      setIsCheckingStatus(true);
-      const tierInfo = await getCurrentTier();
-      if (tierInfo) setCurrentTier(tierInfo);
-      const status = await getPresaleStatus();
-      if (status) {
-        setTotalRaised(status.raised);
-        if (typeof status.presaleEnded === "boolean") {
-          setPresaleEnded(status.presaleEnded);
-        }
-      }
-    } catch (e) {
-      console.error("status error:", e);
-    } finally {
-      setIsCheckingStatus(false);
-    }
-  };
-
-  const checkClaimStatus = async () => {
-    if (!publicKey || !connected) return;
-    try {
-      setIsCheckingStatus(true);
-      const map = await canClaimTokensBulk([publicKey.toString()]);
-      const info = map.get(publicKey.toString());
-      setClaimableTokens(info ? { canClaim: info.canClaim, total: info.total } : null);
-    } catch (e) {
-      toast.error("Failed to check claim status");
-      setClaimableTokens(null);
-    } finally {
-      setIsCheckingStatus(false);
-    }
-  };
-
-  const buyTokens = async () => {
-    toast.info("Starting purchase process...");
-    if (!connected) {
-      try {
-        await connect();
-      } catch {
-        return;
-      }
-    }
-    if (!publicKey) {
-      toast.error("Wallet not connected");
-      return;
-    }
-    if (!amount || parseFloat(amount) <= 0) {
-      toast.error("Invalid amount");
-      return;
-    }
-
-    setIsPending(true);
-    try {
-      const penisAmount = parseFloat(amount);
-      const totalPriceUSDC = penisAmount * currentTier.price_usdc;
-      const feePct = BUY_FEE_PERCENTAGE / 100;
-
-      let txSignature: string | null = null;
-      let total_paid_usdc: number | null = null;
-      let total_paid_sol: number | null = null;
-      let fee_paid_usdc: number | null = null;
-      let fee_paid_sol: number | null = null;
-
-      if (paymentToken === "SOL" && publicKey && signTransaction) {
-        const solAmount = totalPriceUSDC / SOL_TO_USDC_RATE;
-        txSignature = await executeSOLPayment(solAmount, { publicKey, signTransaction, sendTransaction });
-        total_paid_usdc = null;
-        total_paid_sol = +solAmount.toFixed(6);
-        fee_paid_usdc = null;
-        fee_paid_sol = +(solAmount * feePct).toFixed(6);
-      } else if (paymentToken === "USDC" && publicKey && signTransaction) {
-        txSignature = await executeUSDCPayment(totalPriceUSDC, { publicKey, signTransaction, sendTransaction });
-        total_paid_usdc = +totalPriceUSDC.toFixed(6);
-        total_paid_sol = null;
-        fee_paid_usdc = +(totalPriceUSDC * feePct).toFixed(6);
-        fee_paid_sol = null;
-      } else {
-        toast.error("Invalid payment method or wallet not properly connected");
-        throw new Error("payment method");
-      }
-
-      if (!txSignature) throw new Error("No transaction signature returned");
-      (window as any).lastTransactionSignature = txSignature;
-
-      const rec = await recordPurchase({
-        wallet: publicKey.toString(),
-        amount: penisAmount,
-        token: paymentToken,
-        transaction_signature: txSignature,
-        total_paid_usdc: total_paid_usdc ?? undefined,
-        total_paid_sol: total_paid_sol ?? undefined,
-        fee_paid_usdc: fee_paid_usdc ?? undefined,
-        fee_paid_sol: fee_paid_sol ?? undefined,
-        price_usdc_each: currentTier.price_usdc,
-      });
-      if (!rec) {
-        toast.error("Purchase record failed. Try again.");
-        return;
-      }
-
-      setTotalRaised((prev) => prev + penisAmount);
-      setAmount("");
-      checkClaimStatus();
-      toast.success("Purchase completed successfully!");
-    } catch (error) {
-      console.error(error);
-      toast.error("Transaction failed");
-    } finally {
-      setIsPending(false);
-    }
-  };
-
-  const claimTokens = async () => {
-    if (!connected) {
-      try { await connect(); } catch { return; }
-    }
-    if (!publicKey || !claimableTokens?.canClaim || !claimableTokens.total) return;
-    setIsClaimPending(true);
-    try {
-      const tokenAmount = parseFloat(claimableTokens.total);
-      const txSignature = await executeClaimFeePayment({ publicKey, signTransaction, sendTransaction });
-      if (!txSignature) throw new Error("Claim fee payment failed");
-      const resp = await recordClaim({ wallet: publicKey.toString(), transaction_signature: txSignature });
-      if (!resp?.success) throw new Error("Failed to record claim on server");
-      uiToast({ title: "Claim Successful!", description: `You claimed ${tokenAmount.toLocaleString()} PENIS tokens` });
-      setClaimableTokens({ ...claimableTokens, canClaim: false });
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : undefined;
-      uiToast({ title: "Claim Failed", description: message || "Could not complete the claim.", variant: "destructive" });
-    } finally {
-      setIsClaimPending(false);
-    }
-  };
-
-  const raisedPercentage = useMemo(() => (totalRaised / GOAL_TOKENS) * 100, [totalRaised]);
+  if (!currentTier) return null;
 
   return (
     <>
@@ -284,10 +47,7 @@ export default function PresalePage() {
           backgroundSize: "cover",
           backgroundPosition: "center",
           backgroundRepeat: "no-repeat",
-          backgroundAttachment: /iPhone|iPad|iPod/i.test(typeof navigator !== "undefined" ? navigator.userAgent : "")
-  ? "scroll"
-  : "fixed",
-
+          backgroundAttachment: isMobile ? "scroll" : "fixed",
         }}
       >
         <div className="fixed bottom-4 right-4 flex gap-2">
@@ -319,16 +79,12 @@ export default function PresalePage() {
               <CardDescription className="text-center text-gray-300">
                 Current Price: 1 PENIS = {currentTier.price_usdc} USDC
               </CardDescription>
-              {presaleEnded && (
+              {presaleEnded ? (
                 <Badge variant="secondary" className="mx-auto mt-2 bg-pink-500 text-white">
                   Presale Ended - Claim Your Tokens
                 </Badge>
-              )}
-              {!presaleEnded && countdownTime && (
-                <div className="text-center mt-2">
-                  <p className="text-xs text-gray-400">Presale ends in:</p>
-                  <p className="font-mono text-sm">{countdownTime}</p>
-                </div>
+              ) : (
+                <CountdownTimer currentTier={currentTier} />
               )}
             </CardHeader>
 
@@ -351,7 +107,7 @@ export default function PresalePage() {
                 <Progress value={Math.min(100, raisedPercentage)} className="h-2" />
                 <div className="flex justify-between text-xs text-gray-400">
                   <span>{totalRaised.toLocaleString()} PENIS</span>
-                  <span>{GOAL_TOKENS.toLocaleString()} PENIS</span>
+                  <span>{goalTokens.toLocaleString()} PENIS</span>
                 </div>
               </div>
 
@@ -361,57 +117,20 @@ export default function PresalePage() {
                     <h3 className="font-medium">Current Tier: {currentTier.tier}</h3>
                     <p className="text-sm text-gray-400">Price: {currentTier.price_usdc} USDC</p>
                   </div>
-                  {!presaleEnded && countdownTime && currentTier.tier > 3 && (
-                    <div className="text-right">
-                      <p className="text-xs text-gray-400">Tier ends in:</p>
-                      <p className="font-mono">{countdownTime}</p>
-                    </div>
+                  {!presaleEnded && currentTier.tier > 3 && (
+                    <CountdownTimer currentTier={currentTier} label="Tier ends in:" className="text-right" />
                   )}
                 </div>
               </div>
 
-              {connected && (
-                <div className="bg-pink-500/20 p-4 rounded-md border border-pink-500">
-                  <h3 className="font-medium text-center mb-2">
-                    {isCheckingStatus ? "Checking claim status..." : "Token Claim"}
-                  </h3>
-                  {isCheckingStatus ? (
-                    <div className="flex justify-center py-2">
-                      <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-pink-500"></div>
-                    </div>
-                  ) : claimableTokens === null ? (
-                    <p className="text-sm text-center">Unable to check claim status</p>
-                  ) : (
-                    <>
-                      {claimableTokens.total !== undefined && (
-                        <p className="text-sm text-center mb-3">
-                          You can claim{" "}
-                          <span className="font-bold">
-                            {parseInt(claimableTokens.total, 10).toLocaleString()}
-                          </span>{" "}
-                          PENIS tokens
-                        </p>
-                      )}
-                      {presaleEnded && claimableTokens.canClaim ? (
-                        <>
-                          <Button
-                            onClick={claimTokens}
-                            disabled={isClaimPending}
-                            className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600"
-                          >
-                            {isClaimPending ? "Processing..." : "Claim Tokens"}
-                          </Button>
-                          <p className="text-xs text-center mt-2 text-gray-300">
-                            A small fee will be charged to process your claim
-                          </p>
-                        </>
-                      ) : (
-                        <p className="text-sm text-center">Claims open after the presale.</p>
-                      )}
-                    </>
-                  )}
-                </div>
-              )}
+              <ClaimSection
+                connected={connected}
+                isCheckingStatus={isCheckingStatus}
+                claimableTokens={claimableTokens}
+                presaleEnded={presaleEnded}
+                claimTokens={claimTokens}
+                isClaimPending={isClaimPending}
+              />
 
               {!presaleEnded && (
                 <div className="space-y-4">
@@ -421,66 +140,19 @@ export default function PresalePage() {
                       <TabsTrigger value="tiers">Tier Info</TabsTrigger>
                     </TabsList>
                     <TabsContent value="buy" className="space-y-4 pt-4">
-                      <div className="grid gap-2">
-                        <Label htmlFor="amount">Amount of PENIS tokens</Label>
-                        <Input
-                          id="amount"
-                          placeholder="Enter amount"
-                          value={amount}
-                          onChange={(e) => setAmount(e.target.value)}
-                          type="number"
-                          min="1"
-                          className="bg-gray-800/50"
-                        />
-                      </div>
-                      <div className="grid gap-2">
-                        <Label htmlFor="token">Payment Token</Label>
-                        <Select value={paymentToken} onValueChange={(v: any) => setPaymentToken(v as PaymentToken)}>
-                          <SelectTrigger className="bg-gray-800/50">
-                            <SelectValue placeholder="Select token" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="USDC">USDC</SelectItem>
-                            <SelectItem value="SOL">SOL</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                      <Button
-                        onClick={buyTokens}
-                        disabled={!connected || isPending || !amount}
-                        className="w-full bg-gradient-to-r from-pink-500 to-purple-500 hover:from-pink-600 hover:to-purple-600"
-                      >
-                        {isPending ? "Processing..." : "Buy Now"}
-                      </Button>
-                      {!connected && (
-                        <p className="text-center text-sm text-gray-400">Connect your wallet to buy tokens</p>
-                      )}
+                      <PurchaseForm
+                        amount={amount}
+                        setAmount={setAmount}
+                        paymentToken={paymentToken}
+                        setPaymentToken={setPaymentToken}
+                        buyTokens={buyTokens}
+                        isPending={isPending}
+                        connected={connected}
+                      />
                     </TabsContent>
 
                     <TabsContent value="tiers" className="pt-4">
-                      <div className="space-y-2">
-                        {PRESALE_TIERS.map((tier) => (
-                          <div
-                            key={tier.tier}
-                            className={`p-3 rounded-md border ${
-                              currentTier.tier === tier.tier
-                                ? "bg-pink-500/20 border-pink-500"
-                                : "bg-gray-800/50 border-gray-700"
-                            }`}
-                          >
-                            <div className="flex justify-between">
-                              <h4 className="font-medium">Tier {tier.tier}</h4>
-                              <span>{tier.price_usdc} USDC</span>
-                            </div>
-                            <div className="text-xs text-gray-400 mt-1">
-                              <span>Limit: {tier.max_tokens.toLocaleString()} PENIS</span>
-                              {tier.duration_days && (
-                                <span className="ml-2">Duration: {tier.duration_days} days</span>
-                              )}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
+                      <TierInfoList tiers={tiers} currentTier={currentTier} />
                     </TabsContent>
                   </Tabs>
                 </div>

--- a/src/providers/SolanaProviders.tsx
+++ b/src/providers/SolanaProviders.tsx
@@ -3,17 +3,12 @@ import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import "@solana/wallet-adapter-react-ui/styles.css";
 
-const RAW_HTTP = (import.meta as any)?.env?.VITE_SOLANA_RPC_URL as string | undefined;
-const RAW_WS   = (import.meta as any)?.env?.VITE_SOLANA_WS_URL as string | undefined;
+const DEFAULT_RPC_HTTP = "https://api.mainnet-beta.solana.com";
+const RAW_HTTP = (import.meta as { env?: { VITE_SOLANA_RPC_URL?: string } })?.env?.VITE_SOLANA_RPC_URL;
+const RAW_WS   = (import.meta as { env?: { VITE_SOLANA_WS_URL?: string } })?.env?.VITE_SOLANA_WS_URL;
 
-function assertHttps(u?: string) {
-  if (!u || !/^https:\/\//i.test(u)) {
-    throw new Error("VITE_SOLANA_RPC_URL must be a valid https:// endpoint");
-  }
-  return u;
-}
-const HTTP = assertHttps(RAW_HTTP);
-const WS   = RAW_WS && /^wss?:\/\//i.test(RAW_WS) ? RAW_WS : HTTP.replace(/^http/i, "ws");
+const HTTP = RAW_HTTP && /^https:\/\//i.test(RAW_HTTP.trim()) ? RAW_HTTP.trim() : DEFAULT_RPC_HTTP;
+const WS   = RAW_WS && /^wss?:\/\//i.test(RAW_WS.trim()) ? RAW_WS.trim() : HTTP.replace(/^http/i, "ws");
 
 export default function SolanaProviders({ children }: PropsWithChildren) {
   const cfg = useMemo(


### PR DESCRIPTION
## Summary
- expose full tier list at `/tiers` and add `/current-tier` endpoint
- refactor presale page into modular components with shared `usePresale` hook
- parameterize production redirect URL with `VITE_PROD_URL`
- fix build error by removing duplicate `CustomWalletButton` export
- default to mainnet RPC when `VITE_SOLANA_RPC_URL` is missing or invalid to prevent startup crash

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689a5cb96d58832c96c5164baef61cba