### PR TITLE
feat: add loading and error state for presale

### DIFF
--- a/src/hooks/use-presale.ts
+++ b/src/hooks/use-presale.ts
@@ -37,6 +37,7 @@ export function usePresale() {
   const [claimableTokens, setClaimableTokens] = useState<null | { canClaim: boolean; total?: string }>(null);
   const [isClaimPending, setIsClaimPending] = useState(false);
   const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const lastWallet = useRef<string | null>(null);
 
@@ -91,6 +92,7 @@ export function usePresale() {
   const fetchPresaleStatus = async () => {
     try {
       setIsCheckingStatus(true);
+      setError(null);
       const status = await getPresaleStatus();
       if (status) {
         setTotalRaised(status.raised);
@@ -101,6 +103,7 @@ export function usePresale() {
       setTiers(tierList);
     } catch (e) {
       console.error("status error:", e);
+      setError(e instanceof Error ? e.message : "Failed to load presale data");
     } finally {
       setIsCheckingStatus(false);
     }
@@ -226,5 +229,6 @@ export function usePresale() {
     goalTokens,
     raisedPercentage,
     isMobile,
+    error,
   };
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -11,6 +11,7 @@ import TierInfoList from "@/components/TierInfoList";
 import ClaimSection from "@/components/ClaimSection";
 import { formatPublicKey, SPL_MINT_ADDRESS } from "@/lib/solana";
 import { usePresale } from "@/hooks/use-presale";
+import { Spinner } from "@/components/ui/spinner";
 
 export default function PresalePage() {
   const {
@@ -32,9 +33,22 @@ export default function PresalePage() {
     goalTokens,
     raisedPercentage,
     isMobile,
+    error,
   } = usePresale();
 
-  if (!currentTier) return null;
+  if (!currentTier) {
+    return (
+      <div className="flex items-center justify-center min-h-screen text-white">
+        {isCheckingStatus ? (
+          <Spinner className="text-pink-500" size="lg" />
+        ) : error ? (
+          <p>Failed to load presale data: {error}</p>
+        ) : (
+          <p>Presale data unavailable.</p>
+        )}
+      </div>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- show a spinner or message when tier data is loading or fails to load
- track fetch errors in `usePresale` hook and return the message

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689a70ca7874832caba7c47f976c9990