### PR TITLE
feat: add QuikNode RPC failover

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,8 @@
 // src/lib/env.ts
 // Κεντρικό config + ασφαλή fallbacks. Καμία ρίψη σφάλματος στο runtime.
 
+import { Connection } from "@solana/web3.js";
+
 function s(v: unknown): string {
   return typeof v === "string" ? v.trim() : "";
 }
@@ -14,24 +16,51 @@ export const API_BASE_URL =
 
 // --- RPC HTTP/WS (Solana) ---
 // Τα κρατάμε let για να μπορούμε να αυτο-διορθώνουμε στο runtime.
-export let RPC_HTTP =
+const PRIMARY_RPC =
   s(E.VITE_SOLANA_RPC_URL) ||
   "https://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2";
+const QUICKNODE_RPC =
+  s(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (E as any).VITE_SOLANA_QUICKNODE_URL
+  ) || "https://solana-mainnet.quiknode.pro/";
 
-export let RPC_WS =
-  s(E.VITE_SOLANA_WS_URL) ||
-  RPC_HTTP.replace(/^https:/, "wss:");
+export const RPC_URLS = [PRIMARY_RPC, QUICKNODE_RPC];
+
+export let RPC_HTTP = RPC_URLS[0];
+export let RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
+
+async function ping(url: string) {
+  const conn = new Connection(url, { commitment: "processed" });
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("timeout")), 3_000)
+  );
+  await Promise.race([conn.getVersion(), timeout]);
+}
+
+export async function selectRpc() {
+  for (const url of RPC_URLS) {
+    try {
+      await ping(url);
+      return { http: url, ws: url.replace(/^https:/, "wss:") };
+    } catch {
+      console.warn("RPC unreachable:", url);
+    }
+  }
+  const url = RPC_URLS[0];
+  return { http: url, ws: url.replace(/^https:/, "wss:") };
+}
 
 // Δεν πετάμε πια error. Κάνουμε auto-fix + warn.
-export function assertEnv() {
+export async function assertEnv() {
   if (!RPC_HTTP.startsWith("https://")) {
     console.warn(
       "Bad VITE_SOLANA_RPC_URL:",
       JSON.stringify(RPC_HTTP),
       "→ falling back to default"
     );
-    RPC_HTTP =
-      "https://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2";
+    RPC_HTTP = RPC_URLS[0];
+    RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
   }
   if (!/^wss:\/\//.test(RPC_WS)) {
     console.warn(
@@ -40,6 +69,14 @@ export function assertEnv() {
       "→ falling back to default"
     );
     RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
+  }
+
+  try {
+    await ping(RPC_HTTP);
+  } catch {
+    const { http, ws } = await selectRpc();
+    RPC_HTTP = http;
+    RPC_WS = ws;
   }
 
   // Βάλ’ τα στο window για εύκολο έλεγχο από Console

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -17,17 +17,20 @@ import {
 import { RPC_HTTP, RPC_WS, assertEnv } from "@/lib/env";
 
 // ---------- Connection ----------
-export function makeConnection() {
-  assertEnv();
-  return new Connection(RPC_HTTP, {
+export let connection: Connection;
+
+export async function makeConnection() {
+  await assertEnv();
+  connection = new Connection(RPC_HTTP, {
     commitment: "confirmed",
     wsEndpoint: RPC_WS,
     confirmTransactionInitialTimeout: 9_000,
   });
+  return connection;
 }
 
 // Re-use one connection across the app
-export const connection = makeConnection();
+void makeConnection();
 
 // ---------- ENV CONSTANTS ----------
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/src/providers/SolanaProviders.tsx
+++ b/src/providers/SolanaProviders.tsx
@@ -1,20 +1,25 @@
 // src/providers/SolanaProviders.tsx
-import React, { PropsWithChildren, useMemo } from "react";
+import React, { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { PhantomWalletAdapter, SolflareWalletAdapter } from "@solana/wallet-adapter-wallets";
 import "@solana/wallet-adapter-react-ui/styles.css";
-
-const DEFAULT_RPC = "https://api.mainnet-beta.solana.com";
-const endpoint: string =
-  (typeof window !== "undefined" && (window as any).__RPC_OVRD) ||
-  (import.meta?.env?.VITE_PUBLIC_RPC as string) ||
-  DEFAULT_RPC;
+import { RPC_HTTP, RPC_WS, assertEnv } from "@/lib/env";
 
 export default function SolanaProviders({ children }: PropsWithChildren) {
+  const [endpoint, setEndpoint] = useState(RPC_HTTP);
+  const [ws, setWs] = useState(RPC_WS);
+
+  useEffect(() => {
+    assertEnv().then(() => {
+      setEndpoint(RPC_HTTP);
+      setWs(RPC_WS);
+    });
+  }, []);
+
   const wallets = useMemo(() => [new PhantomWalletAdapter(), new SolflareWalletAdapter()], []);
   return (
-    <ConnectionProvider endpoint={endpoint} config={{ commitment: "confirmed" }}>
+    <ConnectionProvider endpoint={endpoint} config={{ commitment: "confirmed", wsEndpoint: ws }}>
       <WalletProvider wallets={wallets} autoConnect={false}>
         <WalletModalProvider>{children}</WalletModalProvider>
       </WalletProvider>


### PR DESCRIPTION
## Summary
- add ordered RPC list with QuikNode fallback and runtime selection
- use selected endpoint for connection and wallet providers

## Testing
- `pnpm lint` *(fails: SmartWalletButton.tsx, mobile.ts, tx.ts, polyfills.ts)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bb78fae50832cadc37528d69d222b