### PR TITLE
Increase Solana transaction confirmation timeouts

### DIFF
--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -22,7 +22,7 @@ export function makeConnection() {
   return new Connection(RPC_HTTP, {
     commitment: "confirmed",
     wsEndpoint: RPC_WS,
-    confirmTransactionInitialTimeout: 9_000,
+    confirmTransactionInitialTimeout: 40_000,
   });
 }
 

--- a/src/lib/tx.ts
+++ b/src/lib/tx.ts
@@ -26,7 +26,7 @@ export async function confirmWithRetry(
 ): Promise<RpcResponseAndContext<SignatureResult>> {
   const commitment = opts?.commitment ?? "confirmed";
   const pollMs = opts?.pollMs ?? 1200;
-  const maxSeconds = opts?.maxSeconds ?? 90;
+  const maxSeconds = opts?.maxSeconds ?? 120;
   const deadline = Date.now() + maxSeconds * 1000;
 
   await waitForVisibility();
@@ -46,7 +46,7 @@ export async function confirmWithRetry(
   const status = await conn.getSignatureStatuses([signature], { searchTransactionHistory: true });
   const st = status?.value?.[0];
   if (st?.err == null && st?.confirmationStatus) {
-    return { context: { apiVersion: null as any, slot: st.slot ?? 0 }, value: { err: null } };
+    return { context: { apiVersion: undefined, slot: st.slot ?? 0 }, value: { err: null } };
   }
   throw new Error("Transaction not confirmed within timeout");
 }
@@ -62,7 +62,7 @@ export async function sendAndAckVersionedTx(
   const sig = await sendTx(tx);
   await confirmWithRetry(conn, sig, { blockhash, lastValidBlockHeight }, {
     commitment: "processed",
-    maxSeconds: 30,
+    maxSeconds: 40,
     pollMs: 600,
   });
   return sig;


### PR DESCRIPTION
## Summary
- Extend RPC connection initial confirmation timeout to 40s
- Allow up to 120s default retries and 40s quick acknowledgement window

## Testing
- `pnpm lint` *(fails: Unexpected any, React hook order, etc.)*
- `npx eslint --quiet src/lib/solana.ts src/lib/tx.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bb78f8c7c832c9a265bbc5ebb4350