### PR TITLE
feat: add QuikNode RPC failover

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 VITE_API_BASE_URL=https://happy-pennis.up.railway.app
 VITE_SOLANA_RPC_URL=https://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2
 VITE_SOLANA_WS_URL=wss://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2
-VITE_SOLANA_RPC_URLhttps://broken-purple-breeze.solana-mainnet.quiknode.pro/b087363c02a61ba4c37f9acd5c3c4dcc7b20420f
+VITE_SOLANA_QUICKNODE_URL=https://broken-purple-breeze.solana-mainnet.quiknode.pro/b087363c02a61ba4c37f9acd5c3c4dcc7b20420f

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,8 @@
 // src/lib/env.ts
 // Κεντρικό config + ασφαλή fallbacks. Καμία ρίψη σφάλματος στο runtime.
 
+import { Connection } from "@solana/web3.js";
+
 function s(v: unknown): string {
   return typeof v === "string" ? v.trim() : "";
 }
@@ -14,24 +16,51 @@ export const API_BASE_URL =
 
 // --- RPC HTTP/WS (Solana) ---
 // Τα κρατάμε let για να μπορούμε να αυτο-διορθώνουμε στο runtime.
-export let RPC_HTTP =
+const PRIMARY_RPC =
   s(E.VITE_SOLANA_RPC_URL) ||
   "https://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2";
+const QUICKNODE_RPC =
+  s(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (E as any).VITE_SOLANA_QUICKNODE_URL
+  ) || "https://solana-mainnet.quiknode.pro/";
 
-export let RPC_WS =
-  s(E.VITE_SOLANA_WS_URL) ||
-  RPC_HTTP.replace(/^https:/, "wss:");
+export const RPC_URLS = [PRIMARY_RPC, QUICKNODE_RPC];
+
+export let RPC_HTTP = RPC_URLS[0];
+export let RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
+
+async function ping(url: string) {
+  const conn = new Connection(url, { commitment: "finalized" });
+  const timeout = new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("timeout")), 3_000)
+  );
+  await Promise.race([conn.getVersion(), timeout]);
+}
+
+export async function selectRpc() {
+  for (const url of RPC_URLS) {
+    try {
+      await ping(url);
+      return { http: url, ws: url.replace(/^https:/, "wss:") };
+    } catch {
+      console.warn("RPC unreachable:", url);
+    }
+  }
+  const url = RPC_URLS[0];
+  return { http: url, ws: url.replace(/^https:/, "wss:") };
+}
 
 // Δεν πετάμε πια error. Κάνουμε auto-fix + warn.
-export function assertEnv() {
+export async function assertEnv() {
   if (!RPC_HTTP.startsWith("https://")) {
     console.warn(
       "Bad VITE_SOLANA_RPC_URL:",
       JSON.stringify(RPC_HTTP),
       "→ falling back to default"
     );
-    RPC_HTTP =
-      "https://solana-mainnet.rpc.extrnode.com/abba3bc7-b46a-4acb-8b15-834781a11ae2";
+    RPC_HTTP = RPC_URLS[0];
+    RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
   }
   if (!/^wss:\/\//.test(RPC_WS)) {
     console.warn(
@@ -40,6 +69,14 @@ export function assertEnv() {
       "→ falling back to default"
     );
     RPC_WS = RPC_HTTP.replace(/^https:/, "wss:");
+  }
+
+  try {
+    await ping(RPC_HTTP);
+  } catch {
+    const { http, ws } = await selectRpc();
+    RPC_HTTP = http;
+    RPC_WS = ws;
   }
 
   // Βάλ’ τα στο window για εύκολο έλεγχο από Console

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -17,17 +17,20 @@ import {
 import { RPC_HTTP, RPC_WS, assertEnv } from "@/lib/env";
 
 // ---------- Connection ----------
-export function makeConnection() {
-  assertEnv();
-  return new Connection(RPC_HTTP, {
-    commitment: "confirmed",
+export let connection: Connection;
+
+export async function makeConnection() {
+  await assertEnv();
+  connection = new Connection(RPC_HTTP, {
+    commitment: "finalized",
     wsEndpoint: RPC_WS,
     confirmTransactionInitialTimeout: 9_000,
   });
+  return connection;
 }
 
 // Re-use one connection across the app
-export const connection = makeConnection();
+void makeConnection();
 
 // ---------- ENV CONSTANTS ----------
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -70,10 +73,10 @@ async function signAndSendTransaction(
     const send = (wallet as any).sendTransaction.bind(wallet);
     const sig: TransactionSignature = await send(transaction, connection, {
       skipPreflight: false,
-      preflightCommitment: "confirmed",
+      preflightCommitment: "finalized",
       maxRetries: 3,
     });
-    const res = await connection.confirmTransaction(sig, "confirmed");
+    const res = await connection.confirmTransaction(sig, "finalized");
     if (res.value?.err) throw new Error("Transaction failed");
     return sig;
   }
@@ -96,7 +99,7 @@ async function signAndSendTransaction(
         blockhash: latest.blockhash,
         lastValidBlockHeight: latest.lastValidBlockHeight,
       },
-      "confirmed"
+      "finalized"
     );
     if (confirmation?.value?.err) throw new Error("Transaction error");
     return signature as TransactionSignature;
@@ -117,11 +120,7 @@ async function signAndSendTransaction(
     while (Date.now() < deadline) {
       const st = await connection.getSignatureStatuses([signature]);
       const s = st.value?.[0];
-      if (
-        s?.confirmationStatus === "confirmed" ||
-        s?.confirmationStatus === "finalized"
-      )
-        break;
+      if (s?.confirmationStatus === "finalized") break;
       await new Promise((r) => setTimeout(r, 500));
     }
     return signature as TransactionSignature;

--- a/src/lib/tx.ts
+++ b/src/lib/tx.ts
@@ -24,7 +24,7 @@ export async function confirmWithRetry(
   params: { blockhash: string; lastValidBlockHeight: number },
   opts?: { commitment?: Commitment; maxSeconds?: number; pollMs?: number }
 ): Promise<RpcResponseAndContext<SignatureResult>> {
-  const commitment = opts?.commitment ?? "confirmed";
+  const commitment = opts?.commitment ?? "finalized";
   const pollMs = opts?.pollMs ?? 1200;
   const maxSeconds = opts?.maxSeconds ?? 90;
   const deadline = Date.now() + maxSeconds * 1000;
@@ -48,7 +48,7 @@ export async function confirmWithRetry(
   if (st?.err == null && st?.confirmationStatus) {
     return { context: { apiVersion: null as any, slot: st.slot ?? 0 }, value: { err: null } };
   }
-  throw new Error("Transaction not confirmed within timeout");
+  throw new Error("Transaction not finalized within timeout");
 }
 
 // Quick ack for fast UI after signing
@@ -58,10 +58,10 @@ export async function sendAndAckVersionedTx(
   sendTx: (tx: VersionedTransaction) => Promise<string>
 ) {
   await sleep(150);
-  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("processed");
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("finalized");
   const sig = await sendTx(tx);
   await confirmWithRetry(conn, sig, { blockhash, lastValidBlockHeight }, {
-    commitment: "processed",
+    commitment: "finalized",
     maxSeconds: 30,
     pollMs: 600,
   });
@@ -74,7 +74,7 @@ export async function sendAndConfirmVersionedTx(
   sendTx: (tx: VersionedTransaction) => Promise<string>
 ) {
   await sleep(250);
-  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("confirmed");
+  const { blockhash, lastValidBlockHeight } = await conn.getLatestBlockhash("finalized");
   const sig = await sendTx(tx);
   await confirmWithRetry(conn, sig, { blockhash, lastValidBlockHeight }, {
     commitment: "finalized",

--- a/src/providers/SolanaProviders.tsx
+++ b/src/providers/SolanaProviders.tsx
@@ -1,20 +1,25 @@
 // src/providers/SolanaProviders.tsx
-import React, { PropsWithChildren, useMemo } from "react";
+import React, { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { ConnectionProvider, WalletProvider } from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { PhantomWalletAdapter, SolflareWalletAdapter } from "@solana/wallet-adapter-wallets";
 import "@solana/wallet-adapter-react-ui/styles.css";
-
-const DEFAULT_RPC = "https://api.mainnet-beta.solana.com";
-const endpoint: string =
-  (typeof window !== "undefined" && (window as any).__RPC_OVRD) ||
-  (import.meta?.env?.VITE_PUBLIC_RPC as string) ||
-  DEFAULT_RPC;
+import { RPC_HTTP, RPC_WS, assertEnv } from "@/lib/env";
 
 export default function SolanaProviders({ children }: PropsWithChildren) {
+  const [endpoint, setEndpoint] = useState(RPC_HTTP);
+  const [ws, setWs] = useState(RPC_WS);
+
+  useEffect(() => {
+    assertEnv().then(() => {
+      setEndpoint(RPC_HTTP);
+      setWs(RPC_WS);
+    });
+  }, []);
+
   const wallets = useMemo(() => [new PhantomWalletAdapter(), new SolflareWalletAdapter()], []);
   return (
-    <ConnectionProvider endpoint={endpoint} config={{ commitment: "confirmed" }}>
+    <ConnectionProvider endpoint={endpoint} config={{ commitment: "finalized", wsEndpoint: ws }}>
       <WalletProvider wallets={wallets} autoConnect={false}>
         <WalletModalProvider>{children}</WalletModalProvider>
       </WalletProvider>


### PR DESCRIPTION
## Summary
- add missing VITE_SOLANA_QUICKNODE_URL env variable to configure QuikNode fallback
- select first responsive RPC URL and expose it across connection and wallet providers
- default all Solana interactions to `finalized` commitment for more reliable confirmations

## Testing
- `pnpm lint` *(fails: SmartWalletButton.tsx, mobile.ts, tx.ts, polyfills.ts)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bb78fae50832cadc37528d69d222b