### PR TITLE
feat: open wallet links in new tab

### DIFF
--- a/src/lib/mobile.ts
+++ b/src/lib/mobile.ts
@@ -50,7 +50,10 @@ export function setPreferredWallet(w: WalletChoice) {
 export function openInWalletBrowser(url: string, wallet?: WalletChoice) {
   const choice = wallet ?? getPreferredWallet();
   const href = deepLinks[choice](url);
-  if (typeof window !== "undefined") window.location.href = href;
+  if (typeof window !== "undefined") {
+    const win = window.open(href, "_blank", "noopener,noreferrer");
+    win?.focus();
+  }
 }
 
 export function walletStoreUrl(wallet: WalletChoice) {


### PR DESCRIPTION
## Summary
- use `window.open` when launching wallet deep links so the presale site stays open
- focus the opened wallet tab

## Testing
- `pnpm lint` *(fails: Unexpected any. Specify a different type in buffer-polyfill.ts, SmartWalletButton.tsx, mobile.ts, polyfills.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689c50664768832cb5c05dbe993b39bb