### PR TITLE
Improve transaction error handling and surface failures

### DIFF
--- a/src/hooks/use-presale.ts
+++ b/src/hooks/use-presale.ts
@@ -180,7 +180,8 @@ export function usePresale() {
       toast.success("Purchase completed successfully!");
     } catch (error) {
       console.error(error);
-      toast.error("Transaction failed");
+      const message = error instanceof Error ? error.message : "Transaction failed";
+      toast.error(message);
     } finally {
       setIsPending(false);
     }


### PR DESCRIPTION
## Summary
- enhance Solana transaction helper to log and throw underlying confirmation errors
- retry sendTransaction with a fresh blockhash when RPC reports "blockhash not found"
- show specific transaction failure messages in presale UI

## Testing
- `pnpm lint` (fails: Unexpected any, empty block statements, hook order)
- `pnpm exec eslint --quiet src/lib/solana.ts src/hooks/use-presale.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689c5066f908832cb488cb8ba17e9f28