### PR TITLE
Restore classic wallet adapter and harden presale backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dataDir = path.join(__dirname, 'test-data');
+process.env.DATA_DIR = dataDir;
+process.env.NODE_ENV = 'test';
+process.env.ADMIN_SECRET = 'test';
+
+await fs.rm(dataDir, { recursive: true, force: true });
+
+const { app, initializeData } = await import('./server.js');
+await initializeData();
+const server = app.listen(0);
+const base = `http://127.0.0.1:${server.address().port}`;
+
+test('malformed JSON in /buy returns 400', async () => {
+  const res = await fetch(base + '/buy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: 'not-json'
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Invalid JSON');
+});
+
+test('negative amount rejected', async () => {
+  const res = await fetch(base + '/buy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      wallet: 'testwallet',
+      amount: -5,
+      token: 'SOL',
+      transaction_signature: 'sig-negative'
+    })
+  });
+  assert.equal(res.status, 400);
+});
+
+test('/debug/migration-status requires admin secret', async () => {
+  const unauth = await fetch(base + '/debug/migration-status');
+  assert.equal(unauth.status, 401);
+
+  const auth = await fetch(base + '/debug/migration-status', {
+    headers: { 'x-admin-secret': 'test' }
+  });
+  assert.equal(auth.status, 200);
+  const body = await auth.json();
+  assert.ok('done' in body);
+});
+
+test('cleanup', () => {
+  server.close();
+});

--- a/src/hooks/use-presale.ts
+++ b/src/hooks/use-presale.ts
@@ -1,157 +1,230 @@
-import { useCallback, useMemo, useState } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
+import { toast } from "sonner";
+import { useToast } from "@/components/ui/use-toast";
 import {
-  Connection, PublicKey, SystemProgram, TransactionInstruction
-} from "@solana/web3.js";
+  executeSOLPayment,
+  executeUSDCPayment,
+  executeClaimFeePayment,
+  BUY_FEE_PERCENTAGE,
+} from "@/lib/solana";
 import {
-  createTransferCheckedInstruction, getAssociatedTokenAddress
-} from "@solana/spl-token";
+  recordPurchase,
+  canClaimTokensBulk,
+  recordClaim,
+  getPresaleStatus,
+  getPresaleTiers,
+  type TierInfo,
+  type PaymentToken,
+} from "@/lib/api";
+import { useIsMobile } from "@/hooks/use-mobile";
 
-import { j } from "@/lib/api";
-import {
-  FEE_WALLET, TREASURY_WALLET, USDC_MINT_ADDRESS,
-  VITE_SOLANA_RPC_URL, COMMITMENT
-} from "@/lib/env";
-import { buildV0Tx, signSendAndConfirm } from "@/lib/solana";
+const SOL_TO_USDC_RATE = 170;
+const PROD_URL = (import.meta.env.VITE_PROD_URL as string) || "https://happypennisofficialpresale.vercel.app/";
 
-// 0.4% fee (0.004). Αν αλλάξει, το αλλάζεις εδώ.
-const FEE_RATE = 0.004;
+export function usePresale() {
+  const { toast: uiToast } = useToast();
+  const { publicKey, connected, signTransaction, sendTransaction, connect } = useWallet();
+  const isMobile = useIsMobile();
 
-const solToLamports  = (sol: number)  => Math.round(sol * 1_000_000_000);
-const usdcToUnits    = (u: number)    => Math.round(u   * 1_000_000);
+  const [tiers, setTiers] = useState<TierInfo[]>([]);
+  const [currentTier, setCurrentTier] = useState<TierInfo | null>(null);
+  const [totalRaised, setTotalRaised] = useState(0);
+  const [amount, setAmount] = useState("");
+  const [paymentToken, setPaymentToken] = useState<PaymentToken>("SOL");
+  const [isPending, setIsPending] = useState(false);
+  const [presaleEnded, setPresaleEnded] = useState(false);
+  const [claimableTokens, setClaimableTokens] = useState<null | { canClaim: boolean; total?: string }>(null);
+  const [isClaimPending, setIsClaimPending] = useState(false);
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
 
-export type PresaleState = { loading: boolean; lastSig?: string; error?: string; };
-export type PresaleActions = {
-  buyWithSOL:  (p: { solAmount: number; tokens: number;  price_usdc_each: number }) => Promise<string>;
-  buyWithUSDC: (p: { usdcAmount: number; tokens: number; price_usdc_each: number }) => Promise<string>;
-  claim:       (p: { tokens: number }) => Promise<string>;
-};
+  const lastWallet = useRef<string | null>(null);
 
-export function usePresale(): [PresaleState, PresaleActions] {
-  const { publicKey, wallet } = useWallet();
-  const [loading, setLoading] = useState(false);
-  const [lastSig, setLastSig] = useState<string | undefined>();
-  const [error, setError]     = useState<string | undefined>();
+  const hasInjected = () => {
+    if (typeof window === "undefined") return false;
+    const w = window as typeof window & { solana?: { isPhantom?: boolean }; solflare?: unknown };
+    return w.solana?.isPhantom || w.solflare;
+  };
 
-  const connection = useMemo(
-    () => new Connection(VITE_SOLANA_RPC_URL, { commitment: COMMITMENT }),
-    []
-  );
+  useEffect(() => {
+    if (isMobile && hasInjected() && !connected) connect().catch(() => {});
+  }, [connected, connect, isMobile]);
 
-  const guard = useCallback(() => {
-    if (!wallet || !publicKey) throw new Error("Σύνδεσε wallet πρώτα.");
-  }, [wallet, publicKey]);
-
-  // Δύο μεταφορές σε SOL: net -> treasury, fee -> fee wallet
-  const buildSOLPurchaseIxs = useCallback((from: PublicKey, lamportsTotal: number) => {
-    const feeLamports = Math.max(Math.floor(lamportsTotal * FEE_RATE), 0);
-    const netLamports = lamportsTotal - feeLamports;
-    if (netLamports <= 0) throw new Error("Ποσό SOL πολύ μικρό μετά το fee.");
-
-    const ixs: TransactionInstruction[] = [
-      SystemProgram.transfer({ fromPubkey: from, toPubkey: TREASURY_WALLET, lamports: netLamports }),
-    ];
-    if (feeLamports > 0) {
-      ixs.push(SystemProgram.transfer({ fromPubkey: from, toPubkey: FEE_WALLET, lamports: feeLamports }));
+  useEffect(() => {
+    if (connected) {
+      const target = PROD_URL;
+      if (typeof window !== "undefined" && window.location.href !== target) {
+        window.location.href = target;
+      }
     }
-    return { ixs, feeLamports, netLamports };
+  }, [connected]);
+
+  useEffect(() => {
+    if (connected && publicKey) {
+      const key = publicKey.toString();
+      if (lastWallet.current !== key) {
+        lastWallet.current = key;
+        checkClaimStatus();
+      }
+    } else {
+      setClaimableTokens(null);
+      lastWallet.current = null;
+    }
+  }, [connected, publicKey]);
+
+  useEffect(() => {
+    fetchPresaleStatus();
   }, []);
 
-  // Δύο transferChecked για USDC: net -> treasury, fee -> fee wallet (decimals = 6)
-  const buildUSDCPurchaseIxs = useCallback(async (from: PublicKey, usdcUnitsTotal: number) => {
-    const feeUnits = Math.max(Math.floor(usdcUnitsTotal * FEE_RATE), 0);
-    const netUnits = usdcUnitsTotal - feeUnits;
-    if (netUnits <= 0) throw new Error("Ποσό USDC πολύ μικρό μετά το fee.");
-
-    const fromAta     = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, from, false);
-    const treasuryAta = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, TREASURY_WALLET, true);
-    const feeAta      = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, FEE_WALLET, true);
-
-    const ixs: TransactionInstruction[] = [
-      createTransferCheckedInstruction(fromAta, USDC_MINT_ADDRESS, treasuryAta, from, netUnits, 6),
-    ];
-    if (feeUnits > 0) {
-      ixs.push(createTransferCheckedInstruction(fromAta, USDC_MINT_ADDRESS, feeAta, from, feeUnits, 6));
+  useEffect(() => {
+    if (!tiers.length) return;
+    let raisedSoFar = 0;
+    for (const tier of tiers) {
+      if (raisedSoFar + tier.max_tokens > totalRaised) {
+        setCurrentTier(tier);
+        break;
+      }
+      raisedSoFar += tier.max_tokens;
     }
-    return { ixs, feeUnits, netUnits };
-  }, []);
+  }, [totalRaised, tiers]);
 
-  const buyWithSOL: PresaleActions["buyWithSOL"] = useCallback(async ({ solAmount, tokens, price_usdc_each }) => {
-    setLoading(true); setError(undefined);
+  const fetchPresaleStatus = async () => {
     try {
-      guard();
-      const lamportsTotal = solToLamports(solAmount);
-      const { ixs, feeLamports, netLamports } = buildSOLPurchaseIxs(publicKey!, lamportsTotal);
+      setIsCheckingStatus(true);
+      const status = await getPresaleStatus();
+      if (status) {
+        setTotalRaised(status.raised);
+        setPresaleEnded(!!status.presaleEnded);
+        setCurrentTier(status.currentTier);
+      }
+      const tierList = await getPresaleTiers();
+      setTiers(tierList);
+    } catch (e) {
+      console.error("status error:", e);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
 
-      const _tx = await buildV0Tx(publicKey!, ixs, connection); // για το blockhash
-      const sig = await signSendAndConfirm(wallet!, publicKey!, ixs);
-
-      await j("/buy", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          amount: tokens,
-          token: "SOL",
-          transaction_signature: sig,
-          total_paid_sol: (netLamports + feeLamports) / 1_000_000_000,
-          fee_paid_sol:   feeLamports / 1_000_000_000,
-          price_usdc_each,
-        }),
-      });
-
-      setLastSig(sig);
-      return sig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, wallet, connection, buildSOLPurchaseIxs, guard]);
-
-  const buyWithUSDC: PresaleActions["buyWithUSDC"] = useCallback(async ({ usdcAmount, tokens, price_usdc_each }) => {
-    setLoading(true); setError(undefined);
+  const checkClaimStatus = async () => {
+    if (!publicKey || !connected) return;
     try {
-      guard();
-      const units = usdcToUnits(usdcAmount);
-      const { ixs, feeUnits, netUnits } = await buildUSDCPurchaseIxs(publicKey!, units);
+      setIsCheckingStatus(true);
+      const map = await canClaimTokensBulk([publicKey.toString()]);
+      const info = map.get(publicKey.toString());
+      setClaimableTokens(info ? { canClaim: info.canClaim, total: info.total } : null);
+    } catch {
+      toast.error("Failed to check claim status");
+      setClaimableTokens(null);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
 
-      const _tx = await buildV0Tx(publicKey!, ixs, connection);
-      const sig = await signSendAndConfirm(wallet!, publicKey!, ixs);
+  const buyTokens = async () => {
+    toast.info("Starting purchase process...");
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey) { toast.error("Wallet not connected"); return; }
+    if (!amount || parseFloat(amount) <= 0 || !currentTier) { toast.error("Invalid amount"); return; }
 
-      await j("/buy", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          amount: tokens,
-          token: "USDC",
-          transaction_signature: sig,
-          total_paid_usdc: (netUnits + feeUnits) / 1_000_000,
-          fee_paid_usdc:   feeUnits / 1_000_000,
-          price_usdc_each,
-        }),
-      });
-
-      setLastSig(sig);
-      return sig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, wallet, connection, buildUSDCPurchaseIxs, guard]);
-
-  const claim: PresaleActions["claim"] = useCallback(async ({ tokens }) => {
-    setLoading(true); setError(undefined);
+    setIsPending(true);
     try {
-      guard();
-      const fakeSig = `claim_${Date.now()}`;
-      await j("/claim", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          transaction_signature: fakeSig,
-          tokens,
-        }),
-      });
-      setLastSig(fakeSig);
-      return fakeSig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, guard]);
+      const penisAmount = parseFloat(amount);
+      const totalPriceUSDC = penisAmount * currentTier.price_usdc;
+      const feePct = BUY_FEE_PERCENTAGE / 100;
+      let txSignature: string | null = null;
+      let total_paid_usdc: number | null = null;
+      let total_paid_sol: number | null = null;
+      let fee_paid_usdc: number | null = null;
+      let fee_paid_sol: number | null = null;
 
-  return [{ loading, lastSig, error }, { buyWithSOL, buyWithUSDC, claim }];
+      if (paymentToken === "SOL" && publicKey && signTransaction) {
+        const solAmount = totalPriceUSDC / SOL_TO_USDC_RATE;
+        txSignature = await executeSOLPayment(solAmount, { publicKey, signTransaction, sendTransaction });
+        total_paid_sol = +solAmount.toFixed(6);
+        fee_paid_sol = +(solAmount * feePct).toFixed(6);
+      } else if (paymentToken === "USDC" && publicKey && signTransaction) {
+        txSignature = await executeUSDCPayment(totalPriceUSDC, { publicKey, signTransaction, sendTransaction });
+        total_paid_usdc = +totalPriceUSDC.toFixed(6);
+        fee_paid_usdc = +(totalPriceUSDC * feePct).toFixed(6);
+      } else {
+        toast.error("Invalid payment method or wallet not properly connected");
+        throw new Error("payment method");
+      }
+
+      if (!txSignature) throw new Error("No transaction signature returned");
+      (window as unknown as { lastTransactionSignature?: string }).lastTransactionSignature = txSignature;
+
+      const rec = await recordPurchase({
+        wallet: publicKey.toString(),
+        amount: penisAmount,
+        token: paymentToken,
+        transaction_signature: txSignature,
+        total_paid_usdc: total_paid_usdc ?? undefined,
+        total_paid_sol: total_paid_sol ?? undefined,
+        fee_paid_usdc: fee_paid_usdc ?? undefined,
+        fee_paid_sol: fee_paid_sol ?? undefined,
+        price_usdc_each: currentTier.price_usdc,
+      });
+      if (!rec) { toast.error("Purchase record failed. Try again."); return; }
+
+      setTotalRaised((prev) => prev + penisAmount);
+      setAmount("");
+      checkClaimStatus();
+      toast.success("Purchase completed successfully!");
+    } catch (error) {
+      console.error(error);
+      toast.error("Transaction failed");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const claimTokens = async () => {
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey || !claimableTokens?.canClaim || !claimableTokens.total) return;
+    setIsClaimPending(true);
+    try {
+      const tokenAmount = parseFloat(claimableTokens.total);
+      const txSignature = await executeClaimFeePayment({ publicKey, signTransaction, sendTransaction });
+      if (!txSignature) throw new Error("Claim fee payment failed");
+      const resp = await recordClaim({ wallet: publicKey.toString(), transaction_signature: txSignature });
+      if (!resp?.success) throw new Error("Failed to record claim on server");
+      uiToast({ title: "Claim Successful!", description: `You claimed ${tokenAmount.toLocaleString()} PENIS tokens` });
+      setClaimableTokens({ ...claimableTokens, canClaim: false });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : undefined;
+      uiToast({ title: "Claim Failed", description: message || "Could not complete the claim.", variant: "destructive" });
+    } finally {
+      setIsClaimPending(false);
+    }
+  };
+
+  const goalTokens = useMemo(() => tiers.reduce((s, t) => s + (t.max_tokens || 0), 0), [tiers]);
+  const raisedPercentage = useMemo(() => (totalRaised / goalTokens) * 100, [totalRaised, goalTokens]);
+
+  return {
+    tiers,
+    currentTier,
+    totalRaised,
+    amount,
+    setAmount,
+    paymentToken,
+    setPaymentToken,
+    isPending,
+    presaleEnded,
+    claimableTokens,
+    isClaimPending,
+    isCheckingStatus,
+    buyTokens,
+    claimTokens,
+    connected,
+    goalTokens,
+    raisedPercentage,
+    isMobile,
+  };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,28 +1,137 @@
 // src/lib/api.ts
-const RAW = import.meta.env.VITE_API_BASE_URL as string;   // π.χ. https://happy-pennis.up.railway.app
-if (!RAW) console.warn("[ENV] VITE_API_BASE_URL is empty");
-const BASE = RAW.replace(/\/+$/, "");                      // κόψε τυχόν τελικά '/'
 
-function url(path: string) {
-  return path.startsWith("/") ? `${BASE}${path}` : `${BASE}/${path}`;
+// Base URL (Railway) με δυνατότητα override από Vercel env
+const RAW =
+  (import.meta as { env?: { VITE_API_BASE_URL?: string } })?.env?.VITE_API_BASE_URL ||
+  "https://happy-pennis.up.railway.app";
+export const API_BASE_URL = String(RAW).replace(/\/+$/, "");
+
+// για debug στο browser
+if (typeof window !== "undefined") {
+  (window as unknown as { __API_BASE__?: string }).__API_BASE__ = API_BASE_URL;
 }
 
-export async function j<T>(path: string, init?: RequestInit): Promise<T> {
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), 15000); // 15s timeout για να μη μένεις «λευκός»
-  try {
-    const res = await fetch(url(path), {
-      ...init,
-      headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
-      signal: ctrl.signal,
-      // credentials: "include", // μόνο αν χρησιμοποιείς cookies
-    });
-    if (!res.ok) {
-      const txt = await res.text().catch(() => "");
-      throw new Error(`API ${res.status} ${res.statusText} @ ${url(path)} ${txt ? "– " + txt : ""}`);
+async function j<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    mode: "cors",
+    cache: "no-store",
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    let msg = `API ${res.status} ${res.statusText} @ ${path}`;
+    try {
+      const e = await res.json();
+      if (e?.error) msg = e.error;
+    } catch {
+      try {
+        msg = await res.text();
+      } catch {
+        /* ignore */
+      }
     }
-    return (await res.json()) as T;
-  } finally {
-    clearTimeout(t);
+    throw new Error(msg);
   }
+  return (await res.json()) as T;
+}
+
+async function tryAlt<T>(fn: () => Promise<T>, alt: () => Promise<T>) {
+  try {
+    return await fn();
+  } catch (e: unknown) {
+    const s = String((e as { message?: string })?.message || "");
+    if (/(404|405)/.test(s)) return await alt();
+    throw e;
+  }
+}
+
+// ---- types ----
+export type TierInfo = { tier: number; price_usdc: number; max_tokens: number; duration_days?: number | null };
+export type PaymentToken = "SOL" | "USDC";
+export type PresaleStatus = {
+  raised: number;
+  currentTier: TierInfo;
+  totalPurchases: number;
+  totalClaims: number;
+  spl_address: string;
+  fee_wallet: string;
+  presaleEnded?: boolean;
+};
+export type PurchaseRecord = {
+  id: number; wallet: string; token: "SOL" | "USDC"; amount: number; tier: number;
+  transaction_signature: string; timestamp: string; claimed: boolean;
+  total_paid_usdc?: number; total_paid_sol?: number;
+  fee_paid_usdc?: number;   fee_paid_sol?: number;
+  price_usdc_each?: number;
+};
+export type WalletClaimStatus = { wallet: string; canClaim: boolean; total?: string };
+
+// ---- API calls ----
+export async function getCurrentTier(): Promise<TierInfo> {
+  const status = await getPresaleStatus();
+  return status.currentTier;
+}
+export const getPresaleStatus = () => j<PresaleStatus>("/status");
+export const getPresaleTiers = () => j<TierInfo[]>("/tiers");
+
+export async function canClaimTokensBulk(wallets: string[]) {
+  if (wallets.length === 1) {
+    const w = wallets[0];
+    const one = await tryAlt<{ wallet: string; canClaim: boolean; total?: string | number }>(
+      () => j(`/can-claim/${encodeURIComponent(w)}`),
+      () =>
+        j("/can-claim", {
+          method: "POST",
+          body: JSON.stringify({ wallets: [w] }),
+        }).then((arr: { wallet: string; canClaim: boolean; total?: string | number }[]) =>
+          (arr && arr[0]) || { wallet: w, canClaim: false }
+        )
+    );
+
+    const map = new Map<string, WalletClaimStatus>();
+    map.set(w, {
+      wallet: w,
+      canClaim: !!one.canClaim,
+      total: one.total != null ? String(one.total) : undefined,
+    });
+    return map;
+  }
+
+  const out = await j<Array<{ wallet: string; canClaim: boolean; total?: string | number }>>(
+    "/can-claim",
+    { method: "POST", body: JSON.stringify({ wallets }) }
+  );
+  const map = new Map<string, WalletClaimStatus>();
+  for (const r of out) {
+    map.set(r.wallet, {
+      wallet: r.wallet,
+      canClaim: !!r.canClaim,
+      total: r.total != null ? String(r.total) : undefined,
+    });
+  }
+  return map;
+}
+
+export function recordPurchase(data: {
+  wallet: string;
+  amount: number;
+  token: "SOL" | "USDC";
+  transaction_signature: string;
+  total_paid_usdc?: number;
+  total_paid_sol?: number;
+  fee_paid_usdc?: number;
+  fee_paid_sol?: number;
+  price_usdc_each?: number;
+}) {
+  return j<PurchaseRecord>("/buy", { method: "POST", body: JSON.stringify(data) });
+}
+
+export function recordClaim(data: { wallet: string; transaction_signature: string }) {
+  return j<{ success: true }>("/claim", { method: "POST", body: JSON.stringify(data) });
+}
+
+export const getSnapshot = () => j<PurchaseRecord[]>("/snapshot");
+
+export function downloadSnapshotCSV(): void {
+  window.open(`${API_BASE_URL}/export`, "_blank");
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,7 +3,8 @@ import { PublicKey } from "@solana/web3.js";
 
 // Διαβάζουμε ΟΛΑ από import.meta.env (Vite)
 export const VITE_API_BASE_URL   = (import.meta.env.VITE_API_BASE_URL   ?? "").replace(/\/+$/, "");
-export const VITE_SOLANA_RPC_URL =  import.meta.env.VITE_SOLANA_RPC_URL ?? "";
+export const VITE_SOLANA_RPC_URL =
+  import.meta.env.VITE_SOLANA_RPC_URL ?? import.meta.env.VITE_SOLANA_QUICKNODE_URL ?? "";
 export const VITE_SOLANA_WS_URL  =  import.meta.env.VITE_SOLANA_WS_URL  ?? "";
 export const VITE_CANONICAL_URL  =  import.meta.env.VITE_CANONICAL_URL  ?? "";
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_SOLANA_RPC_URL: string;
   readonly VITE_SOLANA_WS_URL: string; // optional αλλά το δηλώνουμε
+  readonly VITE_SOLANA_QUICKNODE_URL: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;


### PR DESCRIPTION
## Summary
- restore original presale hook and API helper so tiers load and wallet adapter works across devices
- reinstate solana utility with SOL/USDC purchase helpers and claim fee support
- validate purchase payload JSON and numeric fields, sanitize user data, protect debug routes with admin secret
- fall back to QuickNode RPC URL when primary Solana endpoint missing
- rename local env holder in `solana.ts` to `ENV_VARS` to avoid bundler redeclaration

## Testing
- `npm test --prefix backend`
- `pnpm lint` *(fails: Unexpected any / no-empty / react-hooks/rules-of-hooks)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689caf4ff454832c999b83486f17b2a1