### PR TITLE
Restore classic wallet adapter and harden presale backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import fs from 'fs/promises';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dataDir = path.join(__dirname, 'test-data');
+process.env.DATA_DIR = dataDir;
+process.env.NODE_ENV = 'test';
+process.env.ADMIN_SECRET = 'test';
+
+await fs.rm(dataDir, { recursive: true, force: true });
+
+const { app, initializeData } = await import('./server.js');
+await initializeData();
+const server = app.listen(0);
+const base = `http://127.0.0.1:${server.address().port}`;
+
+test('malformed JSON in /buy returns 400', async () => {
+  const res = await fetch(base + '/buy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'text/plain' },
+    body: 'not-json'
+  });
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.error, 'Invalid JSON');
+});
+
+test('negative amount rejected', async () => {
+  const res = await fetch(base + '/buy', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      wallet: 'testwallet',
+      amount: -5,
+      token: 'SOL',
+      transaction_signature: 'sig-negative'
+    })
+  });
+  assert.equal(res.status, 400);
+});
+
+test('/debug/migration-status requires admin secret', async () => {
+  const unauth = await fetch(base + '/debug/migration-status');
+  assert.equal(unauth.status, 401);
+
+  const auth = await fetch(base + '/debug/migration-status', {
+    headers: { 'x-admin-secret': 'test' }
+  });
+  assert.equal(auth.status, 200);
+  const body = await auth.json();
+  assert.ok('done' in body);
+});
+
+test('cleanup', () => {
+  server.close();
+});

--- a/src/hooks/use-presale.ts
+++ b/src/hooks/use-presale.ts
@@ -1,157 +1,230 @@
-import { useCallback, useMemo, useState } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
+import { toast } from "sonner";
+import { useToast } from "@/components/ui/use-toast";
 import {
-  Connection, PublicKey, SystemProgram, TransactionInstruction
-} from "@solana/web3.js";
+  executeSOLPayment,
+  executeUSDCPayment,
+  executeClaimFeePayment,
+  BUY_FEE_PERCENTAGE,
+} from "@/lib/solana";
 import {
-  createTransferCheckedInstruction, getAssociatedTokenAddress
-} from "@solana/spl-token";
+  recordPurchase,
+  canClaimTokensBulk,
+  recordClaim,
+  getPresaleStatus,
+  getPresaleTiers,
+  type TierInfo,
+  type PaymentToken,
+} from "@/lib/api";
+import { useIsMobile } from "@/hooks/use-mobile";
 
-import { j } from "@/lib/api";
-import {
-  FEE_WALLET, TREASURY_WALLET, USDC_MINT_ADDRESS,
-  VITE_SOLANA_RPC_URL, COMMITMENT
-} from "@/lib/env";
-import { buildV0Tx, signSendAndConfirm } from "@/lib/solana";
+const SOL_TO_USDC_RATE = 170;
+const PROD_URL = (import.meta.env.VITE_PROD_URL as string) || "https://happypennisofficialpresale.vercel.app/";
 
-// 0.4% fee (0.004). Αν αλλάξει, το αλλάζεις εδώ.
-const FEE_RATE = 0.004;
+export function usePresale() {
+  const { toast: uiToast } = useToast();
+  const { publicKey, connected, signTransaction, sendTransaction, connect } = useWallet();
+  const isMobile = useIsMobile();
 
-const solToLamports  = (sol: number)  => Math.round(sol * 1_000_000_000);
-const usdcToUnits    = (u: number)    => Math.round(u   * 1_000_000);
+  const [tiers, setTiers] = useState<TierInfo[]>([]);
+  const [currentTier, setCurrentTier] = useState<TierInfo | null>(null);
+  const [totalRaised, setTotalRaised] = useState(0);
+  const [amount, setAmount] = useState("");
+  const [paymentToken, setPaymentToken] = useState<PaymentToken>("SOL");
+  const [isPending, setIsPending] = useState(false);
+  const [presaleEnded, setPresaleEnded] = useState(false);
+  const [claimableTokens, setClaimableTokens] = useState<null | { canClaim: boolean; total?: string }>(null);
+  const [isClaimPending, setIsClaimPending] = useState(false);
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
 
-export type PresaleState = { loading: boolean; lastSig?: string; error?: string; };
-export type PresaleActions = {
-  buyWithSOL:  (p: { solAmount: number; tokens: number;  price_usdc_each: number }) => Promise<string>;
-  buyWithUSDC: (p: { usdcAmount: number; tokens: number; price_usdc_each: number }) => Promise<string>;
-  claim:       (p: { tokens: number }) => Promise<string>;
-};
+  const lastWallet = useRef<string | null>(null);
 
-export function usePresale(): [PresaleState, PresaleActions] {
-  const { publicKey, wallet } = useWallet();
-  const [loading, setLoading] = useState(false);
-  const [lastSig, setLastSig] = useState<string | undefined>();
-  const [error, setError]     = useState<string | undefined>();
+  const hasInjected = () => {
+    if (typeof window === "undefined") return false;
+    const w = window as typeof window & { solana?: { isPhantom?: boolean }; solflare?: unknown };
+    return w.solana?.isPhantom || w.solflare;
+  };
 
-  const connection = useMemo(
-    () => new Connection(VITE_SOLANA_RPC_URL, { commitment: COMMITMENT }),
-    []
-  );
+  useEffect(() => {
+    if (isMobile && hasInjected() && !connected) connect().catch(() => {});
+  }, [connected, connect, isMobile]);
 
-  const guard = useCallback(() => {
-    if (!wallet || !publicKey) throw new Error("Σύνδεσε wallet πρώτα.");
-  }, [wallet, publicKey]);
-
-  // Δύο μεταφορές σε SOL: net -> treasury, fee -> fee wallet
-  const buildSOLPurchaseIxs = useCallback((from: PublicKey, lamportsTotal: number) => {
-    const feeLamports = Math.max(Math.floor(lamportsTotal * FEE_RATE), 0);
-    const netLamports = lamportsTotal - feeLamports;
-    if (netLamports <= 0) throw new Error("Ποσό SOL πολύ μικρό μετά το fee.");
-
-    const ixs: TransactionInstruction[] = [
-      SystemProgram.transfer({ fromPubkey: from, toPubkey: TREASURY_WALLET, lamports: netLamports }),
-    ];
-    if (feeLamports > 0) {
-      ixs.push(SystemProgram.transfer({ fromPubkey: from, toPubkey: FEE_WALLET, lamports: feeLamports }));
+  useEffect(() => {
+    if (connected) {
+      const target = PROD_URL;
+      if (typeof window !== "undefined" && window.location.href !== target) {
+        window.location.href = target;
+      }
     }
-    return { ixs, feeLamports, netLamports };
+  }, [connected]);
+
+  useEffect(() => {
+    if (connected && publicKey) {
+      const key = publicKey.toString();
+      if (lastWallet.current !== key) {
+        lastWallet.current = key;
+        checkClaimStatus();
+      }
+    } else {
+      setClaimableTokens(null);
+      lastWallet.current = null;
+    }
+  }, [connected, publicKey]);
+
+  useEffect(() => {
+    fetchPresaleStatus();
   }, []);
 
-  // Δύο transferChecked για USDC: net -> treasury, fee -> fee wallet (decimals = 6)
-  const buildUSDCPurchaseIxs = useCallback(async (from: PublicKey, usdcUnitsTotal: number) => {
-    const feeUnits = Math.max(Math.floor(usdcUnitsTotal * FEE_RATE), 0);
-    const netUnits = usdcUnitsTotal - feeUnits;
-    if (netUnits <= 0) throw new Error("Ποσό USDC πολύ μικρό μετά το fee.");
-
-    const fromAta     = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, from, false);
-    const treasuryAta = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, TREASURY_WALLET, true);
-    const feeAta      = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, FEE_WALLET, true);
-
-    const ixs: TransactionInstruction[] = [
-      createTransferCheckedInstruction(fromAta, USDC_MINT_ADDRESS, treasuryAta, from, netUnits, 6),
-    ];
-    if (feeUnits > 0) {
-      ixs.push(createTransferCheckedInstruction(fromAta, USDC_MINT_ADDRESS, feeAta, from, feeUnits, 6));
+  useEffect(() => {
+    if (!tiers.length) return;
+    let raisedSoFar = 0;
+    for (const tier of tiers) {
+      if (raisedSoFar + tier.max_tokens > totalRaised) {
+        setCurrentTier(tier);
+        break;
+      }
+      raisedSoFar += tier.max_tokens;
     }
-    return { ixs, feeUnits, netUnits };
-  }, []);
+  }, [totalRaised, tiers]);
 
-  const buyWithSOL: PresaleActions["buyWithSOL"] = useCallback(async ({ solAmount, tokens, price_usdc_each }) => {
-    setLoading(true); setError(undefined);
+  const fetchPresaleStatus = async () => {
     try {
-      guard();
-      const lamportsTotal = solToLamports(solAmount);
-      const { ixs, feeLamports, netLamports } = buildSOLPurchaseIxs(publicKey!, lamportsTotal);
+      setIsCheckingStatus(true);
+      const status = await getPresaleStatus();
+      if (status) {
+        setTotalRaised(status.raised);
+        setPresaleEnded(!!status.presaleEnded);
+        setCurrentTier(status.currentTier);
+      }
+      const tierList = await getPresaleTiers();
+      setTiers(tierList);
+    } catch (e) {
+      console.error("status error:", e);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
 
-      const _tx = await buildV0Tx(publicKey!, ixs, connection); // για το blockhash
-      const sig = await signSendAndConfirm(wallet!, publicKey!, ixs);
-
-      await j("/buy", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          amount: tokens,
-          token: "SOL",
-          transaction_signature: sig,
-          total_paid_sol: (netLamports + feeLamports) / 1_000_000_000,
-          fee_paid_sol:   feeLamports / 1_000_000_000,
-          price_usdc_each,
-        }),
-      });
-
-      setLastSig(sig);
-      return sig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, wallet, connection, buildSOLPurchaseIxs, guard]);
-
-  const buyWithUSDC: PresaleActions["buyWithUSDC"] = useCallback(async ({ usdcAmount, tokens, price_usdc_each }) => {
-    setLoading(true); setError(undefined);
+  const checkClaimStatus = async () => {
+    if (!publicKey || !connected) return;
     try {
-      guard();
-      const units = usdcToUnits(usdcAmount);
-      const { ixs, feeUnits, netUnits } = await buildUSDCPurchaseIxs(publicKey!, units);
+      setIsCheckingStatus(true);
+      const map = await canClaimTokensBulk([publicKey.toString()]);
+      const info = map.get(publicKey.toString());
+      setClaimableTokens(info ? { canClaim: info.canClaim, total: info.total } : null);
+    } catch {
+      toast.error("Failed to check claim status");
+      setClaimableTokens(null);
+    } finally {
+      setIsCheckingStatus(false);
+    }
+  };
 
-      const _tx = await buildV0Tx(publicKey!, ixs, connection);
-      const sig = await signSendAndConfirm(wallet!, publicKey!, ixs);
+  const buyTokens = async () => {
+    toast.info("Starting purchase process...");
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey) { toast.error("Wallet not connected"); return; }
+    if (!amount || parseFloat(amount) <= 0 || !currentTier) { toast.error("Invalid amount"); return; }
 
-      await j("/buy", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          amount: tokens,
-          token: "USDC",
-          transaction_signature: sig,
-          total_paid_usdc: (netUnits + feeUnits) / 1_000_000,
-          fee_paid_usdc:   feeUnits / 1_000_000,
-          price_usdc_each,
-        }),
-      });
-
-      setLastSig(sig);
-      return sig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, wallet, connection, buildUSDCPurchaseIxs, guard]);
-
-  const claim: PresaleActions["claim"] = useCallback(async ({ tokens }) => {
-    setLoading(true); setError(undefined);
+    setIsPending(true);
     try {
-      guard();
-      const fakeSig = `claim_${Date.now()}`;
-      await j("/claim", {
-        method: "POST",
-        body: JSON.stringify({
-          wallet: publicKey!.toBase58(),
-          transaction_signature: fakeSig,
-          tokens,
-        }),
-      });
-      setLastSig(fakeSig);
-      return fakeSig;
-    } catch (e: any) { setError(e?.message ?? String(e)); throw e; }
-    finally { setLoading(false); }
-  }, [publicKey, guard]);
+      const penisAmount = parseFloat(amount);
+      const totalPriceUSDC = penisAmount * currentTier.price_usdc;
+      const feePct = BUY_FEE_PERCENTAGE / 100;
+      let txSignature: string | null = null;
+      let total_paid_usdc: number | null = null;
+      let total_paid_sol: number | null = null;
+      let fee_paid_usdc: number | null = null;
+      let fee_paid_sol: number | null = null;
 
-  return [{ loading, lastSig, error }, { buyWithSOL, buyWithUSDC, claim }];
+      if (paymentToken === "SOL" && publicKey && signTransaction) {
+        const solAmount = totalPriceUSDC / SOL_TO_USDC_RATE;
+        txSignature = await executeSOLPayment(solAmount, { publicKey, signTransaction, sendTransaction });
+        total_paid_sol = +solAmount.toFixed(6);
+        fee_paid_sol = +(solAmount * feePct).toFixed(6);
+      } else if (paymentToken === "USDC" && publicKey && signTransaction) {
+        txSignature = await executeUSDCPayment(totalPriceUSDC, { publicKey, signTransaction, sendTransaction });
+        total_paid_usdc = +totalPriceUSDC.toFixed(6);
+        fee_paid_usdc = +(totalPriceUSDC * feePct).toFixed(6);
+      } else {
+        toast.error("Invalid payment method or wallet not properly connected");
+        throw new Error("payment method");
+      }
+
+      if (!txSignature) throw new Error("No transaction signature returned");
+      (window as unknown as { lastTransactionSignature?: string }).lastTransactionSignature = txSignature;
+
+      const rec = await recordPurchase({
+        wallet: publicKey.toString(),
+        amount: penisAmount,
+        token: paymentToken,
+        transaction_signature: txSignature,
+        total_paid_usdc: total_paid_usdc ?? undefined,
+        total_paid_sol: total_paid_sol ?? undefined,
+        fee_paid_usdc: fee_paid_usdc ?? undefined,
+        fee_paid_sol: fee_paid_sol ?? undefined,
+        price_usdc_each: currentTier.price_usdc,
+      });
+      if (!rec) { toast.error("Purchase record failed. Try again."); return; }
+
+      setTotalRaised((prev) => prev + penisAmount);
+      setAmount("");
+      checkClaimStatus();
+      toast.success("Purchase completed successfully!");
+    } catch (error) {
+      console.error(error);
+      toast.error("Transaction failed");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const claimTokens = async () => {
+    if (!connected) {
+      try { await connect(); } catch { return; }
+    }
+    if (!publicKey || !claimableTokens?.canClaim || !claimableTokens.total) return;
+    setIsClaimPending(true);
+    try {
+      const tokenAmount = parseFloat(claimableTokens.total);
+      const txSignature = await executeClaimFeePayment({ publicKey, signTransaction, sendTransaction });
+      if (!txSignature) throw new Error("Claim fee payment failed");
+      const resp = await recordClaim({ wallet: publicKey.toString(), transaction_signature: txSignature });
+      if (!resp?.success) throw new Error("Failed to record claim on server");
+      uiToast({ title: "Claim Successful!", description: `You claimed ${tokenAmount.toLocaleString()} PENIS tokens` });
+      setClaimableTokens({ ...claimableTokens, canClaim: false });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : undefined;
+      uiToast({ title: "Claim Failed", description: message || "Could not complete the claim.", variant: "destructive" });
+    } finally {
+      setIsClaimPending(false);
+    }
+  };
+
+  const goalTokens = useMemo(() => tiers.reduce((s, t) => s + (t.max_tokens || 0), 0), [tiers]);
+  const raisedPercentage = useMemo(() => (totalRaised / goalTokens) * 100, [totalRaised, goalTokens]);
+
+  return {
+    tiers,
+    currentTier,
+    totalRaised,
+    amount,
+    setAmount,
+    paymentToken,
+    setPaymentToken,
+    isPending,
+    presaleEnded,
+    claimableTokens,
+    isClaimPending,
+    isCheckingStatus,
+    buyTokens,
+    claimTokens,
+    connected,
+    goalTokens,
+    raisedPercentage,
+    isMobile,
+  };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,28 +1,137 @@
 // src/lib/api.ts
-const RAW = import.meta.env.VITE_API_BASE_URL as string;   // π.χ. https://happy-pennis.up.railway.app
-if (!RAW) console.warn("[ENV] VITE_API_BASE_URL is empty");
-const BASE = RAW.replace(/\/+$/, "");                      // κόψε τυχόν τελικά '/'
 
-function url(path: string) {
-  return path.startsWith("/") ? `${BASE}${path}` : `${BASE}/${path}`;
+// Base URL (Railway) με δυνατότητα override από Vercel env
+const RAW =
+  (import.meta as { env?: { VITE_API_BASE_URL?: string } })?.env?.VITE_API_BASE_URL ||
+  "https://happy-pennis.up.railway.app";
+export const API_BASE_URL = String(RAW).replace(/\/+$/, "");
+
+// για debug στο browser
+if (typeof window !== "undefined") {
+  (window as unknown as { __API_BASE__?: string }).__API_BASE__ = API_BASE_URL;
 }
 
-export async function j<T>(path: string, init?: RequestInit): Promise<T> {
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), 15000); // 15s timeout για να μη μένεις «λευκός»
-  try {
-    const res = await fetch(url(path), {
-      ...init,
-      headers: { "content-type": "application/json", ...(init?.headers ?? {}) },
-      signal: ctrl.signal,
-      // credentials: "include", // μόνο αν χρησιμοποιείς cookies
-    });
-    if (!res.ok) {
-      const txt = await res.text().catch(() => "");
-      throw new Error(`API ${res.status} ${res.statusText} @ ${url(path)} ${txt ? "– " + txt : ""}`);
+async function j<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    mode: "cors",
+    cache: "no-store",
+    headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+  if (!res.ok) {
+    let msg = `API ${res.status} ${res.statusText} @ ${path}`;
+    try {
+      const e = await res.json();
+      if (e?.error) msg = e.error;
+    } catch {
+      try {
+        msg = await res.text();
+      } catch {
+        /* ignore */
+      }
     }
-    return (await res.json()) as T;
-  } finally {
-    clearTimeout(t);
+    throw new Error(msg);
   }
+  return (await res.json()) as T;
+}
+
+async function tryAlt<T>(fn: () => Promise<T>, alt: () => Promise<T>) {
+  try {
+    return await fn();
+  } catch (e: unknown) {
+    const s = String((e as { message?: string })?.message || "");
+    if (/(404|405)/.test(s)) return await alt();
+    throw e;
+  }
+}
+
+// ---- types ----
+export type TierInfo = { tier: number; price_usdc: number; max_tokens: number; duration_days?: number | null };
+export type PaymentToken = "SOL" | "USDC";
+export type PresaleStatus = {
+  raised: number;
+  currentTier: TierInfo;
+  totalPurchases: number;
+  totalClaims: number;
+  spl_address: string;
+  fee_wallet: string;
+  presaleEnded?: boolean;
+};
+export type PurchaseRecord = {
+  id: number; wallet: string; token: "SOL" | "USDC"; amount: number; tier: number;
+  transaction_signature: string; timestamp: string; claimed: boolean;
+  total_paid_usdc?: number; total_paid_sol?: number;
+  fee_paid_usdc?: number;   fee_paid_sol?: number;
+  price_usdc_each?: number;
+};
+export type WalletClaimStatus = { wallet: string; canClaim: boolean; total?: string };
+
+// ---- API calls ----
+export async function getCurrentTier(): Promise<TierInfo> {
+  const status = await getPresaleStatus();
+  return status.currentTier;
+}
+export const getPresaleStatus = () => j<PresaleStatus>("/status");
+export const getPresaleTiers = () => j<TierInfo[]>("/tiers");
+
+export async function canClaimTokensBulk(wallets: string[]) {
+  if (wallets.length === 1) {
+    const w = wallets[0];
+    const one = await tryAlt<{ wallet: string; canClaim: boolean; total?: string | number }>(
+      () => j(`/can-claim/${encodeURIComponent(w)}`),
+      () =>
+        j("/can-claim", {
+          method: "POST",
+          body: JSON.stringify({ wallets: [w] }),
+        }).then((arr: { wallet: string; canClaim: boolean; total?: string | number }[]) =>
+          (arr && arr[0]) || { wallet: w, canClaim: false }
+        )
+    );
+
+    const map = new Map<string, WalletClaimStatus>();
+    map.set(w, {
+      wallet: w,
+      canClaim: !!one.canClaim,
+      total: one.total != null ? String(one.total) : undefined,
+    });
+    return map;
+  }
+
+  const out = await j<Array<{ wallet: string; canClaim: boolean; total?: string | number }>>(
+    "/can-claim",
+    { method: "POST", body: JSON.stringify({ wallets }) }
+  );
+  const map = new Map<string, WalletClaimStatus>();
+  for (const r of out) {
+    map.set(r.wallet, {
+      wallet: r.wallet,
+      canClaim: !!r.canClaim,
+      total: r.total != null ? String(r.total) : undefined,
+    });
+  }
+  return map;
+}
+
+export function recordPurchase(data: {
+  wallet: string;
+  amount: number;
+  token: "SOL" | "USDC";
+  transaction_signature: string;
+  total_paid_usdc?: number;
+  total_paid_sol?: number;
+  fee_paid_usdc?: number;
+  fee_paid_sol?: number;
+  price_usdc_each?: number;
+}) {
+  return j<PurchaseRecord>("/buy", { method: "POST", body: JSON.stringify(data) });
+}
+
+export function recordClaim(data: { wallet: string; transaction_signature: string }) {
+  return j<{ success: true }>("/claim", { method: "POST", body: JSON.stringify(data) });
+}
+
+export const getSnapshot = () => j<PurchaseRecord[]>("/snapshot");
+
+export function downloadSnapshotCSV(): void {
+  window.open(`${API_BASE_URL}/export`, "_blank");
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,7 +3,8 @@ import { PublicKey } from "@solana/web3.js";
 
 // Διαβάζουμε ΟΛΑ από import.meta.env (Vite)
 export const VITE_API_BASE_URL   = (import.meta.env.VITE_API_BASE_URL   ?? "").replace(/\/+$/, "");
-export const VITE_SOLANA_RPC_URL =  import.meta.env.VITE_SOLANA_RPC_URL ?? "";
+export const VITE_SOLANA_RPC_URL =
+  import.meta.env.VITE_SOLANA_RPC_URL ?? import.meta.env.VITE_SOLANA_QUICKNODE_URL ?? "";
 export const VITE_SOLANA_WS_URL  =  import.meta.env.VITE_SOLANA_WS_URL  ?? "";
 export const VITE_CANONICAL_URL  =  import.meta.env.VITE_CANONICAL_URL  ?? "";
 

--- a/src/lib/solana.ts
+++ b/src/lib/solana.ts
@@ -1,240 +1,166 @@
-// src/lib/solana.ts
-// Σταθερό frontend Solana helper: connection, V0 tx build, confirm, κ.λπ.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* src/lib/solana.ts */
+import type { WalletAdapterProps } from "@solana/wallet-adapter-base";
+import { Connection, PublicKey, Transaction, SystemProgram, LAMPORTS_PER_SOL, TransactionSignature } from "@solana/web3.js";
+import { createTransferInstruction, getAssociatedTokenAddress, getAccount, createAssociatedTokenAccountInstruction } from "@solana/spl-token";
 
-import {
-  Commitment,
-  ComputeBudgetProgram,
-  Connection,
-  PublicKey,
-  RpcResponseAndContext,
-  SignatureResult,
-  SystemProgram,
-  TransactionInstruction,
-  TransactionMessage,
-  VersionedTransaction,
-  AddressLookupTableAccount,
-} from "@solana/web3.js";
+// ===== RPC (HTTPS + WSS) =====
+const ENV_VARS = (import.meta as any)?.env || {};
+const RAW_HTTP = ENV_VARS.VITE_SOLANA_RPC_URL || ENV_VARS.VITE_SOLANA_QUICKNODE_URL || "";
+const RAW_WS   = ENV_VARS.VITE_SOLANA_WS_URL || "";
 
-/* =========== ENV (Vite client-side) =========== */
-const RPC_PRIMARY =
-  (import.meta.env.VITE_SOLANA_RPC_URL as string | undefined) ??
-  "https://api.mainnet-beta.solana.com";
-
-const RPC_FALLBACK =
-  (import.meta.env.VITE_SOLANA_QUICKNODE_URL as string | undefined) ?? "";
-
-const WS_ENDPOINT = import.meta.env.VITE_SOLANA_WS_URL as string | undefined;
-
-export const COMMITMENT: Commitment =
-  ((import.meta.env.VITE_SOLANA_COMMITMENT as Commitment | undefined) ??
-    "confirmed") as Commitment;
-
-const HTTP_TIMEOUT_MS = 30_000;
-
-/* =========== Connection helpers =========== */
-export function makeConnection(rpc = RPC_PRIMARY): Connection {
-  return new Connection(rpc, {
-    commitment: COMMITMENT,
-    wsEndpoint: WS_ENDPOINT,
-    confirmTransactionInitialTimeout: HTTP_TIMEOUT_MS,
-    disableRetryOnRateLimit: false,
-  });
+function assertHttps(u: string) {
+  if (!/^https:\/\//i.test(u)) throw new Error("VITE_SOLANA_RPC_URL must be a valid https:// endpoint");
 }
-let _conn = makeConnection();
-export function getConnection(): Connection { return _conn; }
+const RPC_HTTP = (() => {
+  const u = String(RAW_HTTP).trim();
+  assertHttps(u);
+  return u;
+})();
 
-export async function getHealthyConnection(): Promise<Connection> {
-  const ping = async (c: Connection) => {
-    try { await c.getEpochInfo(COMMITMENT); return true; } catch { return false; }
-  };
-  if (await ping(_conn)) return _conn;
-  if (RPC_FALLBACK && RPC_FALLBACK !== RPC_PRIMARY) {
-    const alt = makeConnection(RPC_FALLBACK);
-    if (await ping(alt)) { _conn = alt; return _conn; }
+// Only use an explicit WS endpoint if it begins with ws:// or wss://.
+// Otherwise, let @solana/web3.js derive it from the HTTP RPC URL.
+const RPC_WS = (() => {
+  const w = String(RAW_WS).trim();
+  if (!w) return undefined;
+  if (!/^wss?:\/\//i.test(w)) {
+    console.warn("[env] Ignoring invalid VITE_SOLANA_WS_URL:", w);
+    return undefined;
   }
-  return _conn;
-}
+  return w;
+})();
 
-/* =========== Small utils =========== */
-export function sleep(ms: number) { return new Promise(r => setTimeout(r, ms)); }
-export async function waitForVisibility(skipOnMobile?: boolean) {
-  if (skipOnMobile || typeof document === "undefined") return;
-  if (document.visibilityState !== "hidden") return;
-  await new Promise<void>((resolve) => {
-    const onVis = () => {
-      if (document.visibilityState !== "hidden") {
-        document.removeEventListener("visibilitychange", onVis);
-        resolve();
-      }
-    };
-    document.addEventListener("visibilitychange", onVis);
-  });
-}
-export function toPublicKey(k: string | PublicKey): PublicKey {
-  return typeof k === "string" ? new PublicKey(k) : k;
-}
-export function formatPublicKey(
-  key: string | PublicKey,
-  opts: { prefix?: number; suffix?: number } = {}
-): string {
-  const { prefix = 4, suffix = 4 } = opts;
-  const base58 = typeof key === "string" ? key : key.toBase58();
-  if (base58.length <= prefix + suffix) return base58;
-  return `${base58.slice(0, prefix)}…${base58.slice(-suffix)}`;
-}
-export const shortAddress = formatPublicKey;
+export const connection = new Connection(RPC_HTTP, {
+  commitment: "confirmed",
+  wsEndpoint: RPC_WS,
+  confirmTransactionInitialTimeout: 90_000,
+});
 
-/* =========== Confirm helpers =========== */
-export async function confirmWithRetry(
-  conn: Connection,
-  signature: string,
-  params: { blockhash: string; lastValidBlockHeight: number },
-  opts?: { commitment?: Commitment; maxSeconds?: number; pollMs?: number; skipOnMobile?: boolean }
-): Promise<RpcResponseAndContext<SignatureResult>> {
-  const commitment = opts?.commitment ?? "finalized";
-  const pollMs = opts?.pollMs ?? 1200;
-  const maxSeconds = opts?.maxSeconds ?? 120;
-  const deadline = Date.now() + maxSeconds * 1000;
+// ===== Constants (βάλε από env εκεί που έχεις ήδη) =====
+export const SPL_MINT_ADDRESS: string =
+  ENV_VARS.VITE_SPL_MINT_ADDRESS || "GgzjNE5YJ8FQ4r1Ts4vfUUq87ppv5qEZQ9uumVM7txGs";
 
-  await waitForVisibility(opts?.skipOnMobile);
-  await sleep(250);
+const TREASURY_WALLET_STR =
+  ENV_VARS.VITE_TREASURY_WALLET || "6fcXfgceVof1Lv6WzNZWSD4jQc9up5ctE3817RE2a9gD";
 
-  while (Date.now() < deadline) {
-    try {
-      const res = await conn.confirmTransaction({ signature, ...params }, commitment);
-      if (res.value.err == null) return res;
-      throw new Error(JSON.stringify(res.value.err));
-    } catch {}
-    await sleep(pollMs);
+const FEE_WALLET_STR =
+  ENV_VARS.VITE_FEE_WALLET || "J2Vz7te8H8gfUSV6epJtLAJsyAjmRpee5cjjDVuR8tWn";
+
+export const BUY_FEE_PERCENTAGE =
+  ENV_VARS.VITE_BUY_FEE_PERCENTAGE ? Number(ENV_VARS.VITE_BUY_FEE_PERCENTAGE) : 2;
+
+export const TREASURY_WALLET = new PublicKey(TREASURY_WALLET_STR);
+export const FEE_WALLET = new PublicKey(FEE_WALLET_STR);
+export const USDC_MINT_ADDRESS = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+
+const toLamports  = (sol: number) => Math.floor(sol * LAMPORTS_PER_SOL);
+const toUSDCUnits = (u: number) => Math.floor(u * 1_000_000);
+
+// ===== Mobile-friendly signer =====
+async function signAndSendTransaction(
+  transaction: Transaction,
+  wallet: Pick<WalletAdapterProps, "publicKey" | "signTransaction"> & { sendTransaction?: any }
+): Promise<TransactionSignature> {
+  if (!wallet?.publicKey) throw new Error("Wallet not connected");
+
+  // 1) Προτίμησε sendTransaction (mobile-friendly)
+  if (typeof (wallet as any).sendTransaction === "function") {
+    const send = (wallet as any).sendTransaction.bind(wallet);
+    const sig: TransactionSignature = await send(transaction, connection, {
+      preflightCommitment: "confirmed",
+      skipPreflight: false,
+      maxRetries: 3,
+    });
+    // Επιβεβαίωση με WS + fallback
+    const latest = await connection.getLatestBlockhash("finalized");
+    const conf = await connection.confirmTransaction(
+      { signature: sig, blockhash: latest.blockhash, lastValidBlockHeight: latest.lastValidBlockHeight },
+      "confirmed"
+    );
+    if (conf.value?.err) throw new Error("Transaction failed");
+    return sig;
   }
 
-  const status = await conn.getSignatureStatuses([signature], { searchTransactionHistory: true });
-  const st = status?.value?.[0];
-  if (st?.err == null && st?.confirmationStatus) {
-    return { context: { apiVersion: undefined, slot: st.slot ?? 0 }, value: { err: null } };
-  }
-  throw new Error("Transaction not finalized within timeout");
-}
+  // 2) Fallback: signTransaction -> sendRawTransaction
+  transaction.feePayer = wallet.publicKey!;
+  const latest = await connection.getLatestBlockhash("finalized");
+  transaction.recentBlockhash = latest.blockhash;
 
-/* =========== NEW: buildV0Tx =========== */
-/**
- * Φτιάχνει **Versioned (v0)** συναλλαγή με optional Compute Budget & Priority Fee.
- * - Χρησιμοποιεί `TransactionMessage` + `VersionedTransaction`.
- * - Δέχεται optional Address Lookup Tables (για μεγάλα tx).
- * Docs: versioned tx & compute budget, getLatestBlockhash. 
- */
-export async function buildV0Tx(opts: {
-  conn: Connection;
-  payer: PublicKey;
-  instructions: TransactionInstruction[];
-  lookupTables?: AddressLookupTableAccount[]; // optional
-  computeUnitLimit?: number;                  // π.χ. 400_000 .. 800_000
-  priorityFeeMicroLamports?: number;          // π.χ. 5_000 .. 50_000
-  recent?: { blockhash: string; lastValidBlockHeight: number }; // αν έχεις ήδη
-}): Promise<{ tx: VersionedTransaction; recent: { blockhash: string; lastValidBlockHeight: number } }> {
-  const { conn, payer, lookupTables = [], computeUnitLimit, priorityFeeMicroLamports } = opts;
-
-  // 1) Προσάρμοσε Compute Budget (αν δοθεί)
-  const pre: TransactionInstruction[] = [];
-  if (computeUnitLimit && computeUnitLimit > 0) {
-    pre.push(ComputeBudgetProgram.setComputeUnitLimit({ units: computeUnitLimit }));
-  }
-  if (priorityFeeMicroLamports && priorityFeeMicroLamports > 0) {
-    pre.push(ComputeBudgetProgram.setComputeUnitPrice({ microLamports: priorityFeeMicroLamports }));
-  }
-
-  // 2) Blockhash (finalized — όπως προτείνουν τα docs)
-  const recent = opts.recent ?? await conn.getLatestBlockhash("finalized");
-
-  // 3) Χτίσιμο V0 message (με ή χωρίς LUTs)
-  const messageV0 = new TransactionMessage({
-    payerKey: payer,
-    recentBlockhash: recent.blockhash,
-    instructions: [...pre, ...opts.instructions],
-  }).compileToV0Message(lookupTables);
-
-  const tx = new VersionedTransaction(messageV0);
-  return { tx, recent };
-}
-
-/* =========== NEW: signSendAndConfirm =========== */
-/**
- * Υπογράφει+στέλνει (wallet adapter) και κάνει **σωστό confirm** με lastValidBlockHeight.
- * - Δουλεύει με VersionedTransaction.
- * - Σε mobile μπορείς να περάσεις skipOnMobile για μικρότερη αναμονή UI.
- * Docs: wallet-adapter sendTransaction, Phantom signAndSend, confirmation flow.
- */
-export async function signSendAndConfirm(args: {
-  conn: Connection;
-  wallet: { sendTransaction: (tx: VersionedTransaction, c: Connection, o?: any) => Promise<string> };
-  tx: VersionedTransaction;
-  recent?: { blockhash: string; lastValidBlockHeight: number };
-  commitment?: Commitment;        // default "finalized"
-  skipOnMobile?: boolean;
-}): Promise<string> {
-  const { conn, wallet, tx } = args;
-  const recent = args.recent ?? (await conn.getLatestBlockhash("finalized"));
-  const sig = await wallet.sendTransaction(tx, conn, {
-    preflightCommitment: "confirmed",
-    maxRetries: 3,
-  });
-  await confirmWithRetry(conn, sig, recent, {
-    commitment: args.commitment ?? "finalized",
-    maxSeconds: 60,
-    pollMs: 900,
-    skipOnMobile: args.skipOnMobile,
-  });
+  const signed = await wallet.signTransaction!(transaction);
+  const sig = await connection.sendRawTransaction(signed.serialize(), { skipPreflight: false, maxRetries: 3 });
+  const conf = await connection.confirmTransaction(
+    { signature: sig, blockhash: latest.blockhash, lastValidBlockHeight: latest.lastValidBlockHeight },
+    "confirmed"
+  );
+  if (conf.value?.err) throw new Error("Transaction failed");
   return sig;
 }
 
-/* =========== Convenience wrappers (αν τα χρειαστείς) =========== */
-export async function sendAndAckVersionedTx(
-  conn: Connection,
-  tx: VersionedTransaction,
-  sendTx: (tx: VersionedTransaction) => Promise<string>,
-  opts?: { skipOnMobile?: boolean }
-) {
-  await sleep(120);
-  const recent = await conn.getLatestBlockhash("finalized");
-  const sig = await sendTx(tx);
-  await confirmWithRetry(conn, sig, recent, {
-    commitment: "finalized",
-    maxSeconds: 30,
-    pollMs: 600,
-    skipOnMobile: opts?.skipOnMobile,
-  });
-  return sig;
-}
-export async function sendAndConfirmVersionedTx(
-  conn: Connection,
-  tx: VersionedTransaction,
-  sendTx: (tx: VersionedTransaction) => Promise<string>,
-  opts?: { skipOnMobile?: boolean }
-) {
-  await sleep(200);
-  const recent = await conn.getLatestBlockhash("finalized");
-  const sig = await sendTx(tx);
-  await confirmWithRetry(conn, sig, recent, {
-    commitment: "finalized",
-    maxSeconds: 90,
-    pollMs: 1200,
-    skipOnMobile: opts?.skipOnMobile,
-  });
-  return sig;
+// ===== SOL Payment (main + fee) =====
+export async function executeSOLPayment(
+  amountSOL: number,
+  wallet: Pick<WalletAdapterProps, "publicKey" | "signTransaction"> & { sendTransaction?: any }
+): Promise<TransactionSignature> {
+  if (!wallet.publicKey) throw new Error("Wallet not properly connected");
+
+  const feePct = BUY_FEE_PERCENTAGE / 100;
+  const mainAmount = amountSOL * (1 - feePct);
+  const feeAmount  = amountSOL * feePct;
+
+  const needed = toLamports(mainAmount + feeAmount) + 5_000;
+  const balance = await connection.getBalance(wallet.publicKey);
+  if (balance < needed) throw new Error("Insufficient SOL balance.");
+
+  const tx = new Transaction().add(
+    SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: TREASURY_WALLET, lamports: toLamports(mainAmount) }),
+    SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: FEE_WALLET,      lamports: toLamports(feeAmount)  }),
+  );
+  return signAndSendTransaction(tx, wallet);
 }
 
-/* =========== Default export (προαιρετικό) =========== */
-export default {
-  getConnection,
-  getHealthyConnection,
-  makeConnection,
-  buildV0Tx,
-  signSendAndConfirm,
-  formatPublicKey,
-  shortAddress,
-  toPublicKey,
-  sendAndAckVersionedTx,
-  sendAndConfirmVersionedTx,
-  confirmWithRetry,
-  COMMITMENT,
-};
+// ===== USDC Payment (main + fee) =====
+export async function executeUSDCPayment(
+  amountUSDC: number,
+  wallet: Pick<WalletAdapterProps, "publicKey" | "signTransaction"> & { sendTransaction?: any }
+): Promise<TransactionSignature> {
+  if (!wallet.publicKey) throw new Error("Wallet not properly connected");
+
+  const feePct  = BUY_FEE_PERCENTAGE / 100;
+  const mainU64 = toUSDCUnits(amountUSDC * (1 - feePct));
+  const feeU64  = toUSDCUnits(amountUSDC * feePct);
+
+  const owner  = wallet.publicKey;
+  const from   = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, owner);
+  const toMain = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, TREASURY_WALLET);
+  const toFee  = await getAssociatedTokenAddress(USDC_MINT_ADDRESS, FEE_WALLET);
+
+  const tx = new Transaction();
+  try { await getAccount(connection, toMain); } catch {
+    tx.add(createAssociatedTokenAccountInstruction(owner, toMain, TREASURY_WALLET, USDC_MINT_ADDRESS));
+  }
+  try { await getAccount(connection, toFee); } catch {
+    tx.add(createAssociatedTokenAccountInstruction(owner, toFee, FEE_WALLET, USDC_MINT_ADDRESS));
+  }
+  if (mainU64 > 0) tx.add(createTransferInstruction(from, toMain, owner, mainU64));
+  if (feeU64  > 0) tx.add(createTransferInstruction(from, toFee,  owner, feeU64));
+
+  return signAndSendTransaction(tx, wallet);
+}
+
+// ===== Claim Fee (flat SOL) =====
+export async function executeClaimFeePayment(
+  wallet: Pick<WalletAdapterProps, "publicKey" | "signTransaction"> & { sendTransaction?: any }
+): Promise<TransactionSignature> {
+  if (!wallet.publicKey) throw new Error("Wallet not properly connected");
+  const claimFeeSOL = ENV_VARS.VITE_CLAIM_FEE_SOL ? Number(ENV_VARS.VITE_CLAIM_FEE_SOL) : 0.0005;
+
+  const tx = new Transaction().add(
+    SystemProgram.transfer({ fromPubkey: wallet.publicKey, toPubkey: FEE_WALLET, lamports: toLamports(claimFeeSOL) })
+  );
+  return signAndSendTransaction(tx, wallet);
+}
+
+export function formatPublicKey(k: string | PublicKey) {
+  const s = typeof k === "string" ? k : k.toBase58();
+  return `${s.slice(0, 6)}...${s.slice(-6)}`;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL: string;
   readonly VITE_SOLANA_RPC_URL: string;
   readonly VITE_SOLANA_WS_URL: string; // optional αλλά το δηλώνουμε
+  readonly VITE_SOLANA_QUICKNODE_URL: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;


### PR DESCRIPTION
## Summary
- restore original presale hook and API helper so tiers load and wallet adapter works across devices
- reinstate solana utility with SOL/USDC purchase helpers and claim fee support
- validate purchase payload JSON and numeric fields, sanitize user data, protect debug routes with admin secret
- fall back to QuickNode RPC URL when primary Solana endpoint missing
- rename local env holder in `solana.ts` to `ENV_VARS` to avoid bundler redeclaration
- ignore invalid `VITE_SOLANA_WS_URL` values so malformed https endpoints no longer break the app

## Testing
- `npm test --prefix backend`
- `pnpm lint` *(fails: Unexpected any / no-empty / react-hooks/rules-of-hooks)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689caf4ff454832c999b83486f17b2a1